### PR TITLE
Optimization: Uncap emulation speed during loading sequences

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -121,6 +121,7 @@ code_in_files = {
         os.path.join('Loader.c'),
     ],
     'payload': [
+        os.path.join('egg', 'core', 'eggColorFader.c'),
         os.path.join('egg', 'core', 'eggHeap.c'),
         os.path.join('egg', 'core', 'eggVideo.S'),
         os.path.join('egg', 'core', 'eggSystem.c'),

--- a/payload/egg/core/eggColorFader.c
+++ b/payload/egg/core/eggColorFader.c
@@ -1,0 +1,87 @@
+#include <revolution.h>
+#include <sp/IOSDolphin.h>
+
+static IOSDolphin sDolphin = -1;
+static bool sDolphinUnavailable = false;
+
+static void Init() {
+    if (sDolphin < 0)
+        sDolphin = IOSDolphin_Open();
+
+    if (sDolphin < 0)
+        sDolphinUnavailable = true;
+}
+
+static bool SetEmuSpeed(u32 percent) {
+    if (sDolphin >= 0) {
+        OSReport("[SPEED] Set speed to %u\n", percent);
+        return IOSDolphin_SetSpeedLimit(sDolphin, percent);
+    }
+    return false;
+}
+
+static u32 GetSpeedLimit() {
+    if (sDolphin < 0)
+        return 0;
+
+    IOSDolphin_SpeedLimitQuery q = IOSDolphin_GetSpeedLimit(sDolphin);
+    if (!q.hasValue)
+        return 0;
+
+    return q.emulationSpeedPercent;
+}
+
+static u32 sEmuSpeedStack[8];
+static s32 sEmuSpeedStackSize = 0;
+
+static void PushEmuSpeed(u32 percent) {
+    if (sEmuSpeedStackSize == 8) {
+        OSReport("[SPEED] Max depth reached\n");
+        return;
+    }
+
+    const u32 old_limit = GetSpeedLimit();
+    if (old_limit == 0) {
+        OSReport("[SPEED] Failed to acquire current speed\n");
+        return;
+    }
+
+    if (SetEmuSpeed(percent)) {
+        sEmuSpeedStack[sEmuSpeedStackSize++] = old_limit;
+    } else {
+        OSReport("[SPEED] Failed to set speedlimit\n");
+    }
+}
+
+static void PopEmuSpeed() {
+    if (sEmuSpeedStackSize > 0) {
+        SetEmuSpeed(sEmuSpeedStack[--sEmuSpeedStackSize]);
+    }
+}
+
+static bool post_fadeIn(bool changed) {
+    if (!sDolphinUnavailable) {
+        Init();
+
+        if (sDolphin >= 0 && changed)
+            PopEmuSpeed();
+    }
+
+    return changed;
+}
+
+static bool post_fadeOut(bool changed) {
+    if (!sDolphinUnavailable) {
+        Init();
+        if (sDolphin >= 0 && changed)
+            PushEmuSpeed(400);  // Unlimited
+    }
+
+    return changed;
+}
+
+bool EGG_ColorFader_fadeIn(void *colorFader);
+bool EGG_ColorFader_fadeOut(void *colorFader);
+
+PATCH_B(EGG_ColorFader_fadeIn + 0x24, post_fadeIn);
+PATCH_B(EGG_ColorFader_fadeOut + 0x28, post_fadeOut);

--- a/symbols.txt
+++ b/symbols.txt
@@ -75,6 +75,10 @@
 0x80242c18 EGG_TaskThread_request
 0x80243d6c EGG_Video_configure
 
+0x80215168 EGG_ColorFader_CT
+0x80215280 EGG_ColorFader_fadeIn
+0x802152A8 EGG_ColorFader_fadeOut
+
 0x80386000 s_systemManager
 0x80386638 MaxEntryNum
 0x8038663c FstStringStart


### PR DESCRIPTION
Drastically reduces (more than halves) loading times on Dolphin, assuming non-toaster hardware.

Closes #157