### PR TITLE
Disable code execution in the MEM2 region

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -281,6 +281,7 @@ code_in_files = {
         os.path.join('payload', 'revolution', 'dvdex.c'),
         os.path.join('payload', 'revolution', 'nand.c'),
         os.path.join('payload', 'revolution', 'os', 'OSError.c'),
+        os.path.join('payload', 'revolution', 'os', 'OSMemory.S'),
         os.path.join('payload', 'revolution', 'os', 'OSThread.S'),
         os.path.join('payload', 'revolution', 'os', 'OSThread.c'),
         os.path.join('payload', 'sp', 'Fatal.c'),

--- a/payload/revolution/os/OSMemory.S
+++ b/payload/revolution/os/OSMemory.S
@@ -1,0 +1,19 @@
+#include <Common.S>
+
+# Invalidate IBAT4
+PATCH_REPLACE_START(ConfigMEM2_56MB, 0x3C)
+    mtspr 561, r7 # IBAT4L
+    nop
+PATCH_REPLACE_END(ConfigMEM2_56MB, 0x3C)
+
+# Invalidate IBAT6
+PATCH_REPLACE_START(ConfigMEM2_56MB, 0x9C)
+    mtspr 565, r7 # IBAT6L
+    nop
+PATCH_REPLACE_END(ConfigMEM2_56MB, 0x9C)
+
+# Invalidate IBAT7
+PATCH_REPLACE_START(ConfigMEM2_56MB, 0xBC)
+    mtspr 567, r7 # IBAT7L
+    nop
+PATCH_REPLACE_END(ConfigMEM2_56MB, 0xBC)

--- a/symbols.txt
+++ b/symbols.txt
@@ -116,6 +116,7 @@
 0x801a75d0 OSGetPhysicalMem1Size
 0x801a75dc OSGetPhysicalMem2Size
 0x801A7684 OSProtectRange
+0x801A792C ConfigMEM2_56MB
 0x801a7eac OSInitMutex
 0x801a7ee4 OSLockMutex
 0x801a7fc0 OSUnlockMutex


### PR DESCRIPTION
These changes will have no effect until the patcher runs before the '.dol' module.