### PR TITLE
Integrate settings, /set command

### DIFF
--- a/fuzz/tests.cpp
+++ b/fuzz/tests.cpp
@@ -12,6 +12,8 @@ extern "C" {
 #include <utility>
 #include <vector>
 
+#include "spClientSettings.hpp"
+
 template <typename TFunctor>
 struct Defer {
     TFunctor mF;
@@ -164,24 +166,22 @@ static void IniTest() {
 }
 
 static void IniTest2() {
-    u32 settings[kSetting_MAX];
+    ClientSettings settings;
+    ClientSettings_init(&settings);
 
-    const BaseSettingsDescriptor *desc = ClientSettings_getDescriptor();
-    SpSetting_ResetToDefault(desc, settings);
+    ClientSettings_reset(&settings);
 
     char buf[512];
-    SpSetting_WriteToIni(buf, sizeof(buf), desc, settings);
+    ClientSettings_writeIni(&settings, buf, sizeof(buf));
 
     SP_LOG("RESULT:\n%s", buf);
 
-    const char *tmp = "[TTs]\nClass=200cc\n";
-    SpSetting_ParseFromIni(tmp, strlen(tmp), desc, settings);
+    ClientSettings_readIni(&settings, StringView_create("[TTs]\nClass=200cc\n"));
     /*
         [BaseSettings.c:53] Setting Class to 200cc (1)
     */
 
-    const char *invalid = "[TTs]\nClass=1cc\n";
-    SpSetting_ParseFromIni(invalid, strlen(invalid), desc, settings);
+    ClientSettings_readIni(&settings, StringView_create("[TTs]\nClass=1cc\n"));
     /*
         [BaseSettings.c:44] Unknown value "1cc" for TTs::Class
         [BaseSettings.c:45] Expected one of:
@@ -189,14 +189,12 @@ static void IniTest2() {
         [BaseSettings.c:47] - 200cc (1)
     */
 
-    const char *invalid2 = "[TTs]\nClass2=200cc\n";
-    SpSetting_ParseFromIni(invalid2, strlen(invalid2), desc, settings);
+    ClientSettings_readIni(&settings, StringView_create("[TTs]\nClass2=200cc\n"));
     /*
         [BaseSettings.c:28] Unknown key TTs::Class2
     */
 
-    const char *invalid3 = "[TTs 3]\nClass=200cc\n";
-    SpSetting_ParseFromIni(invalid3, strlen(invalid3), desc, settings);
+    ClientSettings_readIni(&settings, StringView_create("[TTs 3]\nClass=200cc\n"));
     /*
         [BaseSettings.c:28] Unknown key TTs 3::Class
     */

--- a/include/Common.S
+++ b/include/Common.S
@@ -134,3 +134,5 @@
 #define kSetting_PageTransitions 9
 #define kSetting_RaceInputDisplay 10
 #define kSetting_TaRuleGhostSound 11
+#define kSetting_MiiAvatar 12
+#define kSetting_MiiClient 13

--- a/include/Common.S
+++ b/include/Common.S
@@ -121,3 +121,16 @@
 
 #define PATCH_BL_END(dst, offset) \
     PATCH_BRANCH_END(dst, offset, 0x1)
+
+#define kSetting_DriftMode 0
+#define kSetting_HudLabels 1
+#define kSetting_169_Fov 2
+#define kSetting_MapIcons 3
+#define kSetting_TaRuleClass 4
+#define kSetting_TaRuleGhostSorting 5
+#define kSetting_TaRuleGhostTagVisibility 6
+#define kSetting_TaRuleGhostTagContent 7
+#define kSetting_TaRuleSolidGhosts 8
+#define kSetting_PageTransitions 9
+#define kSetting_RaceInputDisplay 10
+#define kSetting_TaRuleGhostSound 11

--- a/payload/egg/core/eggSystem.c
+++ b/payload/egg/core/eggSystem.c
@@ -205,7 +205,11 @@ static void my_lineCallback(const char *buf, size_t len) {
             OSReport("&a/set: Invalid arguments\n");
             return;
         }
-        ClientSettings_set(&s_saveManager->iniSettings, setting, value);
+        if (s_saveManager->spCurrentLicense < 0) {
+            OSReport("&a/set: No license active\n");
+            return;
+        }
+        ClientSettings_set(&s_saveManager->spLicenses[s_saveManager->spCurrentLicense]->cfg, setting, value);
         return;
     }
 

--- a/payload/egg/core/eggSystem.c
+++ b/payload/egg/core/eggSystem.c
@@ -177,8 +177,10 @@ static void my_lineCallback(const char *buf, size_t len) {
                 "SP_TA_RULE_GHOST_TAG_CONTENT_TIME_NOLEADING",
                 "SP_TA_RULE_GHOST_TAG_CONTENT_DATE",
             };
+            const u32 rule =
+                    SaveManager_getSetting(s_saveManager, kSetting_TaRuleGhostTagContent);
             OSReport("example_command: taRuleGhostTagContent == %s\n",
-                    tagContent[SaveManager_getTaRuleGhostTagContent(s_saveManager) & 3]);
+                    tagContent[rule & 3]);
         }
         return;
     }
@@ -187,11 +189,23 @@ static void my_lineCallback(const char *buf, size_t len) {
         if (s_saveManager == NULL) {
             OSReport("instant_menu: Failed to load Save Manager\n");
         } else {
-            bool menuTrans = !SaveManager_getSettingPageTransitions(s_saveManager);
-            SaveManager_setSettingPageTransitions(s_saveManager, menuTrans);
+            bool menuTrans =
+                    !SaveManager_getSetting(s_saveManager, kSetting_PageTransitions);
+            SaveManager_setSetting(s_saveManager, kSetting_PageTransitions, menuTrans);
             OSReport("instant_menu: Menu transition animations toggled %s\n",
                     sOnOff[menuTrans]);
         }
+        return;
+    }
+
+    if (StringStartsWithCommand(tmp, "/set")) {
+        char setting[64];
+        char value[64];
+        if (2 != sscanf(tmp, "/set %s %s", setting, value)) {
+            OSReport("&a/set: Invalid arguments\n");
+            return;
+        }
+        ClientSettings_set(&s_saveManager->iniSettings, setting, value);
         return;
     }
 

--- a/payload/game/gfx/Camera.S
+++ b/payload/game/gfx/Camera.S
@@ -25,7 +25,8 @@ PATCH_B_START(Camera_805a2034, 0xbc)
     mr r29, r3
     lis r3, s_saveManager@ha
     lwz r3, s_saveManager@l (r3)
-    bl SaveManager_getSetting169Fov
+    li r4, kSetting_169_Fov
+    bl SaveManager_getSetting
     slwi r3, r3, 4
     subf r3, r3, r29
     addi r0, r3, 0x10

--- a/payload/game/kart/KartObjectManager.c
+++ b/payload/game/kart/KartObjectManager.c
@@ -24,7 +24,7 @@ static void my_KartObjectManager_createInstance(void) {
         speedModIsEnabled = vsSpeedModIsEnabled;
         break;
     case GAME_MODE_TIME_ATTACK:
-        speedModIsEnabled = SaveManager_getTaRuleClass(s_saveManager) == SP_TA_RULE_CLASS_200CC;
+        speedModIsEnabled = SaveManager_getSetting(s_saveManager, kSetting_TaRuleClass) == kTaRuleClass_200cc;
         break;
     default:
         speedModIsEnabled = false;
@@ -51,10 +51,10 @@ static bool playerIsSolid(u32 playerId) {
         return true;
     }
 
-    switch (SaveManager_getTaRuleSolidGhosts(s_saveManager)) {
-    case SP_TA_RULE_SOLID_GHOSTS_NONE:
+    switch (SaveManager_getSetting(s_saveManager, kSetting_TaRuleSolidGhosts)) {
+    case kTaRuleSolidGhosts_None:
         return false;
-    case SP_TA_RULE_SOLID_GHOSTS_ALL:
+    case kTaRuleSolidGhosts_All:
         return true;
     default:
         return playerId == s_racePage->watchedPlayerId;
@@ -68,7 +68,7 @@ enum {
 };
 
 static u32 getGhostSoundSetting(u32 playerId) {
-    switch (SaveManager_getTaRuleGhostSound(s_saveManager)) {
+    switch (SaveManager_getSetting(s_saveManager, kSetting_TaRuleGhostSound)) {
     case SP_TA_RULE_GHOST_SOUND_NONE:
         return SOUND_SETTING_NONE;
     case SP_TA_RULE_GHOST_SOUND_ALL:

--- a/payload/game/system/Console.c
+++ b/payload/game/system/Console.c
@@ -63,9 +63,17 @@ static void WriterTextBox_newLine(WriterTextBox *self) {
     self->max_height = 0.0f;
 }
 
-static Rect WriterTextBox_advanceCursor(WriterTextBox *self, float width, float height) {
+static Rect WriterTextBox_advanceCursor(
+        WriterTextBox *self, float width, float height, bool isSpace) {
     // Calc line wrap
-    if (self->base_region.right - (width + self->cursor_x) < 1.0f) {
+    float indentThreshhold = width;
+
+    // Strongly favor word breaks
+    if (isSpace) {
+        indentThreshhold = 10.0f * width;
+    }
+
+    if (self->base_region.right - (width + self->cursor_x) < indentThreshhold) {
         WriterTextBox_newLine(self);
         // Indent
         self->cursor_x += width;
@@ -186,7 +194,8 @@ static void TextWriter_drawCharByColors(
         width *= 0.75f;
     }
 
-    const Rect screen_pos = WriterTextBox_advanceCursor(&self->mBox, width, height);
+    const Rect screen_pos =
+            WriterTextBox_advanceCursor(&self->mBox, width, height, c == '-');
 
     TextWriter_drawQuad(self,    //
             fg_color, bg_color,  // Color
@@ -257,16 +266,17 @@ static char sLastLine[64];
 
 enum {
     LINES = 24,
+    LINE_SIZE = 256,
 };
-static char sHistory[LINES][128];
+static char sHistory[LINES][LINE_SIZE];
 static size_t sHistoryCursor = 0;
 static void AppendToHistory(const char *s) {
     if (sHistoryCursor >= LINES) {
-        memmove(sHistory, sHistory + 1, 128 * (LINES - 1));
+        memmove(sHistory, sHistory + 1, LINE_SIZE * (LINES - 1));
         --sHistoryCursor;
     }
     assert(sHistoryCursor < LINES);
-    snprintf(sHistory[sHistoryCursor++], 127, "&r&f%s", s);
+    snprintf(sHistory[sHistoryCursor++], LINE_SIZE - 1, "&r&f%s", s);
 }
 
 static void Console_create() {
@@ -360,21 +370,39 @@ void Console_calc(void) {
     Console_stateDefault(sFramesSinceLastOpen++);
 }
 void Console_addLine(const char *s, size_t UNUSED(len)) {
-    OSThread *thread = OSGetCurrentThread();
-    if (!sInit || thread == NULL) {
-        SP_SCOPED_NO_INTERRUPTS();
+    // To support being called by an interrupt handler, we can't use a mutex. If a call
+    // was interrupted, the global state could be accesesd in an invalid state.
+    SP_SCOPED_NO_INTERRUPTS();
+
 #if 0
+    OSThread *thread = OSGetCurrentThread();
+    if (thread == NULL) {
         if (thread == NULL) {
             va_list l;
             vprintf("Called with NULL current thread (hack to prevent optimization to "
                     "puts, which dolphin doesn't detect: garbage int %i)\n",
                     l);
         }
-#endif
-        AppendToHistory(s);
-        return;
     }
-
-    SP_SCOPED_MUTEX_LOCK(sConsoleMutex);
+#endif
     AppendToHistory(s);
+}
+
+static void Console_vprintfThreadUnsafe(const char *prefix, const char *s, va_list args) {
+    // 1024 bytes of stack may be too large for some threads, so we store it in BSS.
+    static char formatted[512];
+    vsnprintf(formatted, sizeof(formatted), s, args);
+
+    static char buf[512];
+    const size_t len = snprintf(buf, sizeof(buf), "%s%s", prefix, formatted);
+
+    Console_addLine(buf, len);
+}
+
+void Console_vprintf(const char *prefix, const char *s, va_list args) {
+    // To support being called by an interrupt handler, we can't use a mutex. If a call
+    // was interrupted, the global state could be accesesd in an invalid state.
+    SP_SCOPED_NO_INTERRUPTS();
+
+    Console_vprintfThreadUnsafe(prefix, s, args);
 }

--- a/payload/game/system/Console.h
+++ b/payload/game/system/Console.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <stdarg.h>
+
 void Console_init(void);
 void Console_draw(void);
 void Console_calc(void);
-void Console_addLine(const char* s, size_t len);
+void Console_addLine(const char *s, size_t len);
+void Console_vprintf(const char* prefix, const char *s, va_list args);

--- a/payload/game/system/SaveManager.S
+++ b/payload/game/system/SaveManager.S
@@ -14,7 +14,8 @@ PATCH_B_END(RawLicense_reset, 0x64)
 PATCH_B_START(RawLicense_reset, 0x140)
     lis r3, s_saveManager@ha
     lwz r3, s_saveManager@l (r3)
-    bl SaveManager_getDriftMode
+    li r4, kSetting_DriftMode
+    bl SaveManager_getSetting
     addi r3, r3, 0x1
     lhz r4, 0xea (r31)
     rlwimi r4, r3, 14, 16, 17

--- a/payload/game/system/SaveManager.h
+++ b/payload/game/system/SaveManager.h
@@ -21,7 +21,7 @@ enum {
 };
 
 enum {
-    SP_SAVE_LICENSE_VERSION = 3,
+    SP_SAVE_LICENSE_VERSION = 4,
 };
 
 typedef struct {
@@ -38,9 +38,8 @@ typedef struct {
 typedef struct {
     SpSaveSection;
     MiiId miiId;
-    SpSettingBitField;
 } SpSaveLicense;
-static_assert(sizeof(SpSaveLicense) == 0x18);
+static_assert(sizeof(SpSaveLicense) == 0x14);
 
 enum {
     SP_BUFFER_SIZE = 0x10000, // 64 KiB
@@ -88,6 +87,7 @@ typedef struct {
     u8 *ghostInitStack; // Added
     bool *courseSha1IsValid; // Added
     u8 (*courseSha1s)[0x14]; // Added
+    ClientSettings iniSettings;
 } SaveManager;
 static_assert(offsetof(SaveManager, spBuffer) == 0x25008);
 
@@ -110,35 +110,8 @@ void SaveManager_eraseSpLicense(SaveManager *this);
 
 void SaveManager_createSpLicense(SaveManager *this, const MiiId *miiId);
 
-u32 SaveManager_getDriftMode(const SaveManager *this);
-
-void SaveManager_setDriftMode(SaveManager *this, u32 driftMode);
-
-u32 SaveManager_getSettingHudLabels(const SaveManager *this);
-
-u32 SaveManager_getSetting169Fov(const SaveManager *this);
-
-u32 SaveManager_getSettingMapIcons(const SaveManager *this);
-
-u32 SaveManager_getSettingPageTransitions(const SaveManager *this);
-
-void SaveManager_setSettingPageTransitions(const SaveManager *this, u32 pageTransitions);
-
-u32 SaveManager_getSettingRaceInputDisplay(const SaveManager *this);
-
-void SaveManager_setSettingRaceInputDisplay(SaveManager *this, u32 raceInputDisplay);
-
-u32 SaveManager_getTaRuleClass(const SaveManager *this);
-
-u32 SaveManager_getTaRuleGhostSorting(const SaveManager *this);
-
-u32 SaveManager_getTaRuleGhostTagVisibility(const SaveManager *this);
-
-u32 SaveManager_getTaRuleGhostTagContent(const SaveManager *this);
-
-u32 SaveManager_getTaRuleSolidGhosts(const SaveManager *this);
-
-u32 SaveManager_getTaRuleGhostSound(const SaveManager *this);
+u32 SaveManager_getSetting(const SaveManager *this, SpSettingKey key);
+void SaveManager_setSetting(SaveManager *this, SpSettingKey key, u32 value);
 
 void SaveManager_loadGhostAsync(SaveManager *this, s32 licenseId, u32 category, u32 index,
         u32 courseId);

--- a/payload/game/system/SaveManager.h
+++ b/payload/game/system/SaveManager.h
@@ -30,16 +30,8 @@ typedef struct {
 } SpSaveHeader;
 
 typedef struct {
-    u32 magic;
-    u32 size;
-    u32 version;
-} SpSaveSection;
-
-typedef struct {
-    SpSaveSection;
-    MiiId miiId;
+    ClientSettings cfg;
 } SpSaveLicense;
-static_assert(sizeof(SpSaveLicense) == 0x14);
 
 enum {
     SP_BUFFER_SIZE = 0x10000, // 64 KiB
@@ -77,9 +69,6 @@ typedef struct {
     bool canSave;
     bool spCanSave; // Added (was padding)
     u32 result;
-    void *spBuffer; // Added
-    u32 spSectionCount; // Added
-    SpSaveSection **spSections; // Added
     u32 spLicenseCount; // Added
     SpSaveLicense *spLicenses[MAX_SP_LICENSE_COUNT]; // Added
     s32 spCurrentLicense; // Added
@@ -87,9 +76,7 @@ typedef struct {
     u8 *ghostInitStack; // Added
     bool *courseSha1IsValid; // Added
     u8 (*courseSha1s)[0x14]; // Added
-    ClientSettings iniSettings;
 } SaveManager;
-static_assert(offsetof(SaveManager, spBuffer) == 0x25008);
 
 extern SaveManager *s_saveManager;
 
@@ -126,3 +113,5 @@ bool SaveManager_computeCourseSha1Async(SaveManager *this, u32 courseId);
 const u8 *SaveManager_getCourseSha1(const SaveManager *this, u32 courseId);
 
 extern bool vsSpeedModIsEnabled;
+
+MiiId SaveManager_getMiiId(const SaveManager *this, u32 licenseId);

--- a/payload/game/ui/GhostManagerPage.c
+++ b/payload/game/ui/GhostManagerPage.c
@@ -48,14 +48,14 @@ static int compareGhostIndices(const void *p0, const void *p1) {
     u16 i1 = *(u16 *)p1;
     const RawGhostHeader *h0 = &s_saveManager->rawGhostHeaders[i0];
     const RawGhostHeader *h1 = &s_saveManager->rawGhostHeaders[i1];
-    switch (SaveManager_getTaRuleGhostSorting(s_saveManager)) {
-    case SP_TA_RULE_GHOST_SORTING_FASTEST:
+    switch (SaveManager_getSetting(s_saveManager, kSetting_TaRuleGhostSorting)) {
+    case kTaRuleGhostSorting_Fastest:
         return compareRawGhostHeadersByTime(h0, h1);
-    case SP_TA_RULE_GHOST_SORTING_SLOWEST:
+    case kTaRuleGhostSorting_Slowest:
         return compareRawGhostHeadersByTime(h1, h0);
-    case SP_TA_RULE_GHOST_SORTING_NEWEST:
+    case kTaRuleGhostSorting_Newest:
         return compareRawGhostHeadersByDate(h1, h0);
-    case SP_TA_RULE_GHOST_SORTING_OLDEST:
+    case kTaRuleGhostSorting_Oldest:
         return compareRawGhostHeadersByDate(h0, h1);
     default:
         // Should be unreachable
@@ -70,7 +70,7 @@ void GhostManagerPage_processPopulate(GhostManagerPage *this) {
 
     u32 courseId = s_raceConfig->menuScenario.courseId;
     const u8 *courseSha1 = SaveManager_getCourseSha1(s_saveManager, courseId);
-    bool speedModIsEnabled = SaveManager_getTaRuleClass(s_saveManager) == SP_TA_RULE_CLASS_200CC;
+    bool speedModIsEnabled = SaveManager_getSetting(s_saveManager, kSetting_TaRuleClass) == kTaRuleClass_200cc;
 
     SpGhostList *list = &this->list;
     list->count = 0;

--- a/payload/game/ui/LicenseSelectButton.c
+++ b/payload/game/ui/LicenseSelectButton.c
@@ -118,7 +118,8 @@ void LicenseSelectButton_load(LicenseSelectButton *this, u32 index) {
     MiiGroup_init(&this->miiGroup, 1, 0x1, NULL);
     if (index < s_saveManager->spLicenseCount) {
         LayoutUIControl_setPaneVisible(this, "new", false);
-        MiiGroup_insertFromId(&this->miiGroup, 0, &s_saveManager->spLicenses[index]->miiId);
+        MiiId miiId = SaveManager_getMiiId(s_saveManager, index);
+        MiiGroup_insertFromId(&this->miiGroup, 0, &miiId);
         LayoutUIControl_setPaneVisible(this, "mii", true);
         LayoutUIControl_setMiiPicture(this, "mii", &this->miiGroup, 0, 0);
         MessageInfo info = {

--- a/payload/game/ui/LicenseSettingsPage.c
+++ b/payload/game/ui/LicenseSettingsPage.c
@@ -19,6 +19,7 @@ static const InputHandler_vt onBack_vt = {
 
 static void onSettingControlFront(RadioButtonControlHandler *this, RadioButtonControl *control,
         u32 UNUSED(localPlayerId), s32 selected) {
+    SpSaveLicense *license = s_saveManager->spLicenses[s_saveManager->spCurrentLicense];
     int setting = -1;
     switch (control->index) {
     case 0:
@@ -38,7 +39,7 @@ static void onSettingControlFront(RadioButtonControlHandler *this, RadioButtonCo
         break;
     }
     if (setting != -1) {
-        s_saveManager->iniSettings.mValues[setting] = selected;
+        license->cfg.mValues[setting] = selected;
     }
 
     LicenseSettingsPage *page = CONTAINER_OF(this, LicenseSettingsPage, onSettingControlFront);
@@ -177,22 +178,23 @@ static void LicenseSettingsPage_onInit(Page *base) {
         "RaceInputDisplay",
     };
     for (u32 i = 0; i < ARRAY_SIZE(this->settingControls); i++) {
+        SpSaveLicense *license = s_saveManager->spLicenses[s_saveManager->spCurrentLicense];
         u32 chosen;
         switch (i) {
         case 0:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_HudLabels]; 
+            chosen = license->cfg.mValues[kSetting_HudLabels]; 
             break;
         case 1:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_169_Fov];
+            chosen = license->cfg.mValues[kSetting_169_Fov];
             break;
         case 2:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_MapIcons];
+            chosen = license->cfg.mValues[kSetting_MapIcons];
             break;
         case 3:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_PageTransitions];
+            chosen = license->cfg.mValues[kSetting_PageTransitions];
             break;
         case 4:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_RaceInputDisplay];
+            chosen = license->cfg.mValues[kSetting_RaceInputDisplay];
             break;
         }
         char variant[0x20];

--- a/payload/game/ui/LicenseSettingsPage.c
+++ b/payload/game/ui/LicenseSettingsPage.c
@@ -19,23 +19,26 @@ static const InputHandler_vt onBack_vt = {
 
 static void onSettingControlFront(RadioButtonControlHandler *this, RadioButtonControl *control,
         u32 UNUSED(localPlayerId), s32 selected) {
-    SpSaveLicense *license = s_saveManager->spLicenses[s_saveManager->spCurrentLicense];
+    int setting = -1;
     switch (control->index) {
     case 0:
-        license->settingHudLabels = selected;
+        setting = kSetting_HudLabels;
         break;
     case 1:
-        license->setting169Fov = selected;
+        setting = kSetting_169_Fov;
         break;
     case 2:
-        license->settingMapIcons = selected;
+        setting = kSetting_MapIcons;
         break;
     case 3:
-        license->settingPageTransitions = selected;
+        setting = kSetting_PageTransitions;
         break;
     case 4:
-        license->settingRaceInputDisplay = selected;
+        setting = kSetting_RaceInputDisplay;
         break;
+    }
+    if (setting != -1) {
+        s_saveManager->iniSettings.mValues[setting] = selected;
     }
 
     LicenseSettingsPage *page = CONTAINER_OF(this, LicenseSettingsPage, onSettingControlFront);
@@ -174,23 +177,22 @@ static void LicenseSettingsPage_onInit(Page *base) {
         "RaceInputDisplay",
     };
     for (u32 i = 0; i < ARRAY_SIZE(this->settingControls); i++) {
-        const SpSaveLicense *license = s_saveManager->spLicenses[s_saveManager->spCurrentLicense];
         u32 chosen;
         switch (i) {
         case 0:
-            chosen = license->settingHudLabels;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_HudLabels]; 
             break;
         case 1:
-            chosen = license->setting169Fov;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_169_Fov];
             break;
         case 2:
-            chosen = license->settingMapIcons;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_MapIcons];
             break;
         case 3:
-            chosen = license->settingPageTransitions;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_PageTransitions];
             break;
         case 4:
-            chosen = license->settingRaceInputDisplay;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_RaceInputDisplay];
             break;
         }
         char variant[0x20];

--- a/payload/game/ui/Page.c
+++ b/payload/game/ui/Page.c
@@ -19,7 +19,7 @@ static void my_Page_update(Page *page) {
     switch (page->state) {
     case PAGE_STATE_3:
     case PAGE_STATE_5:
-        if (!SaveManager_getSettingPageTransitions(s_saveManager))
+        if (!SaveManager_getSetting(s_saveManager, kSetting_PageTransitions))
             page->canProceed = true;
         break;
     }

--- a/payload/game/ui/TimeAttackRulesPage.c
+++ b/payload/game/ui/TimeAttackRulesPage.c
@@ -25,22 +25,22 @@ static void onRuleControlFront(RadioButtonControlHandler *this, RadioButtonContr
     SpSaveLicense *license = s_saveManager->spLicenses[s_saveManager->spCurrentLicense];
     switch (control->index) {
     case 0:
-        s_saveManager->iniSettings.mValues[kSetting_TaRuleClass] = selected;
+        license->cfg.mValues[kSetting_TaRuleClass] = selected;
         break;
     case 1:
-        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSorting] = selected;
+        license->cfg.mValues[kSetting_TaRuleGhostSorting] = selected;
         break;
     case 2:
-        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagVisibility] = selected;
+        license->cfg.mValues[kSetting_TaRuleGhostTagVisibility] = selected;
         break;
     case 3:
-        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagContent] = selected;
+        license->cfg.mValues[kSetting_TaRuleGhostTagContent] = selected;
         break;
     case 4:
-        s_saveManager->iniSettings.mValues[kSetting_TaRuleSolidGhosts] = selected;
+        license->cfg.mValues[kSetting_TaRuleSolidGhosts] = selected;
         break;
     case 5:
-        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSound] = selected;
+        license->cfg.mValues[kSetting_TaRuleGhostSound] = selected;
         break;
     }
 
@@ -202,22 +202,22 @@ static void TimeAttackRulesPage_onInit(Page *base) {
         u32 chosen;
         switch (i) {
         case 0:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleClass];
+            chosen = license->cfg.mValues[kSetting_TaRuleClass];
             break;
         case 1:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSorting];
+            chosen = license->cfg.mValues[kSetting_TaRuleGhostSorting];
             break;
         case 2:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagVisibility];
+            chosen = license->cfg.mValues[kSetting_TaRuleGhostTagVisibility];
             break;
         case 3:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagContent];
+            chosen = license->cfg.mValues[kSetting_TaRuleGhostTagContent];
             break;
         case 4:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleSolidGhosts];
+            chosen = license->cfg.mValues[kSetting_TaRuleSolidGhosts];
             break;
         case 5:
-            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSound];
+            chosen = license->cfg.mValues[kSetting_TaRuleGhostSound];
             break;
         }
         char variant[0x20];

--- a/payload/game/ui/TimeAttackRulesPage.c
+++ b/payload/game/ui/TimeAttackRulesPage.c
@@ -25,22 +25,22 @@ static void onRuleControlFront(RadioButtonControlHandler *this, RadioButtonContr
     SpSaveLicense *license = s_saveManager->spLicenses[s_saveManager->spCurrentLicense];
     switch (control->index) {
     case 0:
-        license->taRuleClass = selected;
+        s_saveManager->iniSettings.mValues[kSetting_TaRuleClass] = selected;
         break;
     case 1:
-        license->taRuleGhostSorting = selected;
+        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSorting] = selected;
         break;
     case 2:
-        license->taRuleGhostTagVisibility = selected;
+        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagVisibility] = selected;
         break;
     case 3:
-        license->taRuleGhostTagContent = selected;
+        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagContent] = selected;
         break;
     case 4:
-        license->taRuleSolidGhosts = selected;
+        s_saveManager->iniSettings.mValues[kSetting_TaRuleSolidGhosts] = selected;
         break;
     case 5:
-        license->taRuleGhostSound = selected;
+        s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSound] = selected;
         break;
     }
 
@@ -202,22 +202,22 @@ static void TimeAttackRulesPage_onInit(Page *base) {
         u32 chosen;
         switch (i) {
         case 0:
-            chosen = license->taRuleClass;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleClass];
             break;
         case 1:
-            chosen = license->taRuleGhostSorting;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSorting];
             break;
         case 2:
-            chosen = license->taRuleGhostTagVisibility;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagVisibility];
             break;
         case 3:
-            chosen = license->taRuleGhostTagContent;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostTagContent];
             break;
         case 4:
-            chosen = license->taRuleSolidGhosts;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleSolidGhosts];
             break;
         case 5:
-            chosen = license->taRuleGhostSound;
+            chosen = s_saveManager->iniSettings.mValues[kSetting_TaRuleGhostSound];
             break;
         }
         char variant[0x20];

--- a/payload/game/ui/ctrl/CtrlRace2DMap.S
+++ b/payload/game/ui/ctrl/CtrlRace2DMap.S
@@ -34,7 +34,8 @@ PATCH_BL_START(CtrlRace2DMapCharacter_initSelf, 0x294)
 
     lis r3, s_saveManager@ha
     lwz r3, s_saveManager@l (r3)
-    bl SaveManager_getSettingMapIcons
+    li r4, kSetting_MapIcons
+    bl SaveManager_getSetting
     cmpwi r3, 0x1
 
     mr r3, r28

--- a/payload/game/ui/ctrl/CtrlRaceBase.c
+++ b/payload/game/ui/ctrl/CtrlRaceBase.c
@@ -4,7 +4,7 @@
 
 void CtrlRaceBase_initLabelVisibility(CtrlRaceBase *this, u32 localPlayerCount, const char *pane) {
     if (localPlayerCount <= 2) {
-        if (SaveManager_getSettingHudLabels(s_saveManager) == SP_SETTING_HUD_LABELS_SHOW) {
+        if (SaveManager_getSetting(s_saveManager, kSetting_HudLabels) == kHudLabels_Show) {
             return;
         }
     }

--- a/payload/game/ui/ctrl/CtrlRaceInputDisplay.c
+++ b/payload/game/ui/ctrl/CtrlRaceInputDisplay.c
@@ -230,7 +230,7 @@ static void CtrlRaceInputDisplay_calcSelf(UIControl *base) {
 static void CtrlRaceInputDisplay_draw(UIControl *base) {
     // Perform the check here to support hot-swapping in the future via an in-race license
     // settings editor.
-    if (SaveManager_getSettingRaceInputDisplay(s_saveManager) !=
+    if (SaveManager_getSetting(s_saveManager, kSetting_RaceInputDisplay) !=
             SP_SETTING_RACE_INPUT_DISPLAY_SIMPLE) {
         return;
     }

--- a/payload/game/ui/ctrl/CtrlRaceNameBalloon.S
+++ b/payload/game/ui/ctrl/CtrlRaceNameBalloon.S
@@ -148,7 +148,8 @@ PATCH_BL_START(BalloonManager_calc, 0x48)
     // Check that the tag visibility rule is "watched"
     lis r3, s_saveManager@ha
     lwz r3, s_saveManager@l (r3)
-    bl SaveManager_getTaRuleGhostTagVisibility
+    li r4, kSetting_TaRuleGhostTagVisibility
+    bl SaveManager_getSetting
     cmpwi r3, 0x1
     mr r3, r24
     mtlr r25

--- a/payload/game/ui/ctrl/CtrlRaceNameBalloon.c
+++ b/payload/game/ui/ctrl/CtrlRaceNameBalloon.c
@@ -83,7 +83,7 @@ void CtrlRaceNameBalloon_refreshText(CtrlRaceNameBalloon *this, u32 playerId) {
         return;
     }
 
-    switch (SaveManager_getTaRuleGhostTagContent(s_saveManager)) {
+    switch (SaveManager_getSetting(s_saveManager, kSetting_TaRuleGhostTagContent)) {
     case SP_TA_RULE_GHOST_TAG_CONTENT_NAME:
         CtrlRaceNameBalloon_refreshTextName(this, playerId);
         break;
@@ -113,11 +113,11 @@ void CtrlRaceNameBalloon_calcVisibility(CtrlRaceNameBalloon *this) {
         return;
     }
 
-    switch (SaveManager_getTaRuleGhostTagVisibility(s_saveManager)) {
-    case SP_TA_RULE_GHOST_TAG_VISIBILITY_NONE:
+    switch (SaveManager_getSetting(s_saveManager, kSetting_TaRuleGhostTagVisibility)) {
+    case kTaRuleGhostTagVisibility_None:
         this->isHidden = true;
         return;
-    case SP_TA_RULE_GHOST_TAG_VISIBILITY_WATCHED:
+    case kTaRuleGhostTagVisibility_Watched:
         this->isHidden = this->playerId != (s32)lastWatchedPlayerId;
         return;
     default:

--- a/payload/game/ui/page/DriftSelectPage.S
+++ b/payload/game/ui/page/DriftSelectPage.S
@@ -21,8 +21,9 @@ PATCH_BL_START(DriftSelectPage_onButtonFront, 0x48)
 
     lis r3, s_saveManager@ha
     lwz r3, s_saveManager@l (r3)
-    mr r4, r5
-    bl SaveManager_setDriftMode
+    li r4, kSetting_DriftMode
+    // r5 = value
+    bl SaveManager_setSetting
 
     lwz r5, 0x240 (r31) // Original instruction again
     b DriftSelectPage_onButtonFront + 0x4c

--- a/payload/game/ui/page/TopMenuPage.c
+++ b/payload/game/ui/page/TopMenuPage.c
@@ -10,7 +10,8 @@ void TopMenuPage_initMiiGroup(TopMenuPage *this) {
     MiiGroup_ct(this->miiGroup);
     MiiGroup_init(this->miiGroup, MAX_SP_LICENSE_COUNT, 0x4, NULL);
     for (u32 i = 0; i < s_saveManager->spLicenseCount; i++) {
-        MiiGroup_insertFromId(this->miiGroup, i, &s_saveManager->spLicenses[i]->miiId);
+        MiiId miiId = SaveManager_getMiiId(s_saveManager, i);
+        MiiGroup_insertFromId(this->miiGroup, i, &miiId);
     }
 }
 

--- a/payload/revolution/os/OSError.c
+++ b/payload/revolution/os/OSError.c
@@ -52,19 +52,9 @@ void my_OSReport(const char *msg, ...) {
     LogFile_vprintf(msg, args);
     va_end(args);
 
-    {
-        char formatted[128];
-        va_start(args, msg);
-        vsnprintf(formatted, sizeof(formatted), msg, args);
-        va_end(args);
-
-        const char* prefix = GetPrefix(ClassifyCaller(OSGetStackPointer()));
-
-        char buf[128];
-        const size_t len = snprintf(buf, sizeof(buf), "%s%s",
-                prefix, formatted);
-
-        Console_addLine(buf, len);
-    }
+    const char *prefix = GetPrefix(ClassifyCaller(OSGetStackPointer()));
+    va_start(args, msg);
+    Console_vprintf(prefix, msg, args);
+    va_end(args);
 }
 PATCH_B(OSReport, my_OSReport);

--- a/payload/sp/BaseSettings.c
+++ b/payload/sp/BaseSettings.c
@@ -2,19 +2,27 @@
 #include <revolution.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include "HexParser.h"
 #include "IniReader.h"
 
 // Ignores sections
 void SpSetting_Set(const BaseSettingsDescriptor *desc, u32 *valueArray, const char *key,
         const char *value) {
+    assert(desc != NULL);
+    assert(valueArray != NULL);
+    assert(key != NULL && *key);
+    assert(value != NULL && *value);
+
+    bool hasSetting = false;
     int setting = -1;
     for (size_t i = 0; i < desc->numValues; ++i) {
         if (!strcmp(key, desc->fieldDescriptors[i].name)) {
             setting = i;
+            hasSetting = true;
             break;
         }
     }
-    if (setting == -1) {
+    if (!hasSetting) {
         SP_LOG("Unknown key *::%s", key);
         SP_LOG("Expected one of:");
         char validKeys[256];
@@ -31,35 +39,52 @@ void SpSetting_Set(const BaseSettingsDescriptor *desc, u32 *valueArray, const ch
         return;
     }
     const Setting *spSetting = &desc->fieldDescriptors[setting];
+    const char *category = desc->categoryNames[spSetting->category];
 
-    int valueIt = -1;
+    // Default to hex
+    if (spSetting->numEnumValues == 0) {
+        const u32 valueHex = parse_hex32(value, value + strlen(value));
+        SP_LOG("Setting %s::%s to %08x (%i)", category, spSetting->name, valueHex,
+                valueHex);
+        valueArray[setting] = valueHex;
+        return;
+    }
+
+    u32 valueIt;
+    bool hasValue = false;
     for (size_t i = 0; i < spSetting->numEnumValues; ++i) {
         if (!strcmp(spSetting->enumValues[i], value)) {
             valueIt = i;
+            hasValue = true;
             break;
         }
     }
 
-    if (valueIt == -1) {
-        SP_LOG("Unknown value \"%s\" for %s::%s", value,
-                desc->categoryNames[spSetting->category], spSetting->name);
+    if (!hasValue) {
+        SP_LOG("Unknown value \"%s\" for %s::%s", value, category, spSetting->name);
         SP_LOG("Expected one of:");
         for (size_t i = 0; i < spSetting->numEnumValues; ++i) {
             SP_LOG("- %s (%u)", spSetting->enumValues[i], (unsigned)i);
         }
         return;
     }
-    SP_LOG("Setting %s::%s to %s (%i)", desc->categoryNames[spSetting->category],
-            spSetting->name, spSetting->enumValues[valueIt], valueIt);
+    SP_LOG("Setting %s::%s to %s (%i)", category, spSetting->name,
+            spSetting->enumValues[valueIt], valueIt);
     valueArray[setting] = valueIt;
 }
 
 void SpSetting_ParseFromIni(const char *str, size_t len,
         const BaseSettingsDescriptor *desc, u32 *valueArray) {
+    assert(str != NULL);
+    assert(len > 0);
+    assert(desc != NULL);
+    assert(valueArray != NULL);
+
     IniRange iniRange = IniRange_create(str, len);
 
     IniProperty prop;
     while (IniRange_next(&iniRange, &prop)) {
+        bool hasSetting = false;
         int setting = -1;
         for (size_t i = 0; i < desc->numValues; ++i) {
             const Setting *fieldDescriptor = &desc->fieldDescriptors[i];
@@ -73,9 +98,10 @@ void SpSetting_ParseFromIni(const char *str, size_t len,
             }
 
             setting = i;
+            hasSetting = true;
             break;
         }
-        if (setting == -1) {
+        if (!hasSetting) {
             const char *section_cstr = sv_as_cstr(prop.section, 64);
             const char *key_cstr = sv_as_cstr(prop.key, 64);
             SP_LOG("Unknown key %s::%s", section_cstr, key_cstr);
@@ -83,23 +109,35 @@ void SpSetting_ParseFromIni(const char *str, size_t len,
         }
         const Setting *spSetting = &desc->fieldDescriptors[setting];
 
-        int value = -1;
-        for (size_t i = 0; i < spSetting->numEnumValues; ++i) {
-            if (StringView_equalsCStr(prop.value, spSetting->enumValues[i])) {
-                value = i;
-                break;
-            }
+        // Default to hex
+        if (spSetting->numEnumValues == 0) {
+            const u32 value = parse_hex32(prop.value.s, prop.value.s + prop.value.len);
+            SP_LOG("Setting %s to %08x (%i)", spSetting->name, value, value);
+            valueArray[setting] = value;
+            continue;
         }
 
-        if (value == -1) {
-            const char *value_cstr = sv_as_cstr(prop.value, 64);
-            SP_LOG("Unknown value \"%s\" for %s::%s", value_cstr,
-                    desc->categoryNames[spSetting->category], spSetting->name);
-            SP_LOG("Expected one of:");
+        u32 value;
+        {
+            bool hasValue = false;
             for (size_t i = 0; i < spSetting->numEnumValues; ++i) {
-                SP_LOG("- %s (%u)", spSetting->enumValues[i], (unsigned)i);
+                if (StringView_equalsCStr(prop.value, spSetting->enumValues[i])) {
+                    value = i;
+                    hasValue = true;
+                    break;
+                }
             }
-            continue;
+
+            if (!hasValue) {
+                const char *value_cstr = sv_as_cstr(prop.value, 64);
+                SP_LOG("Unknown value \"%s\" for %s::%s", value_cstr,
+                        desc->categoryNames[spSetting->category], spSetting->name);
+                SP_LOG("Expected one of:");
+                for (size_t i = 0; i < spSetting->numEnumValues; ++i) {
+                    SP_LOG("- %s (%u)", spSetting->enumValues[i], (unsigned)i);
+                }
+                continue;
+            }
         }
 
         SP_LOG("Setting %s to %s (%i)", spSetting->name, spSetting->enumValues[value],
@@ -122,6 +160,11 @@ static void Print(char **buf, size_t *maxlen, const char *s, ...) {
 }
 void SpSetting_WriteToIni(char *buf, size_t maxlen, const BaseSettingsDescriptor *desc,
         const u32 *valueArray) {
+    assert(buf != NULL);
+    assert(maxlen > 0);
+    assert(desc != NULL);
+    assert(valueArray != NULL);
+
     u32 lastCategory = ~0;
     for (size_t i = 0; i < desc->numValues; ++i) {
         const Setting *spSetting = &desc->fieldDescriptors[i];
@@ -130,6 +173,13 @@ void SpSetting_WriteToIni(char *buf, size_t maxlen, const BaseSettingsDescriptor
             Print(&buf, &maxlen, "\n[%s]\n", desc->categoryNames[spSetting->category]);
             lastCategory = spSetting->category;
         }
+
+        // 0 -> hex
+        if (spSetting->numEnumValues == 0) {
+            Print(&buf, &maxlen, "%s = %08X\n", spSetting->name, valueArray[i]);
+            continue;
+        }
+
         Print(&buf, &maxlen, "%s = %s\n", spSetting->name,
                 spSetting->enumValues[valueArray[i]]);
     }

--- a/payload/sp/BaseSettings.h
+++ b/payload/sp/BaseSettings.h
@@ -23,3 +23,7 @@ void SpSetting_ParseFromIni(
 void SpSetting_WriteToIni(
         char *buf, size_t maxlen, const BaseSettingsDescriptor *desc, const u32 *valueArray);
 void SpSetting_ResetToDefault(const BaseSettingsDescriptor *desc, u32 *valueArray);
+
+// Ignores sections
+void SpSetting_Set(const BaseSettingsDescriptor *desc, u32 *valueArray, const char *key,
+        const char *value);

--- a/payload/sp/ClientSettings.c
+++ b/payload/sp/ClientSettings.c
@@ -59,6 +59,7 @@ static const char *kTaRuleGhostSound[] = {
 static const char *kCategory[] = {
     [kCategory_Race] = "Race",
     [kCategory_TA] = "TTs",
+    [kCategory_License] = "License",
 };
 
 #define REGISTER_SETTING(Id, Name, Category, Enum)                          \
@@ -82,6 +83,16 @@ static const Setting SpSettings[] = {
     REGISTER_SETTING(kSetting_RaceInputDisplay, "InputDisplay", kCategory_Race, kRaceInputDisplay),
     REGISTER_SETTING(kSetting_TaRuleGhostSound, "GhostSound", kCategory_TA, kTaRuleGhostSound),
     // clang-format on
+    [kSetting_MiiAvatar] = (Setting){ .name = "MiiAvatar",
+            .category = kCategory_License,
+            .defaultValue = 0x80000001,
+            .enumValues = NULL,
+            .numEnumValues = 0 },
+    [kSetting_MiiClient] = (Setting){ .name = "MiiClient",
+            .category = kCategory_License,
+            .defaultValue = 0xECFF82D2,
+            .enumValues = NULL,
+            .numEnumValues = 0 },
 };
 static const BaseSettingsDescriptor SpSettingsDesc = (BaseSettingsDescriptor){
     .numValues = ARRAY_SIZE(SpSettings),

--- a/payload/sp/ClientSettings.h
+++ b/payload/sp/ClientSettings.h
@@ -206,12 +206,18 @@ typedef enum {
     kSetting_RaceInputDisplay = 10,
     kSetting_TaRuleGhostSound = 11,
 
+    // BE encoding of u8[4]
+    kSetting_MiiAvatar = 12,
+    // BE encoding of u8[4]
+    kSetting_MiiClient = 13,
+
     kSetting_MAX,
 } SpSettingKey;
 
 enum {
     kCategory_Race,
     kCategory_TA,
+    kCategory_License,
 
     kCategory_MAX,
 };

--- a/payload/sp/HexParser.h
+++ b/payload/sp/HexParser.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <Common.h>
+
+/*
+static inline
+u32 value_or_null(u32 val, bool cond) {
+        // 1 -> 0xFFFF'FFFF
+        // 0 -> 0x0000'0000
+        u32 mask = ~(static_cast<u32>(cond) - 1);
+        return val & mask;
+}
+*/
+#define value_or_null(val, cond) ((val) & (~(((u32)(cond)) - 1)))
+
+// is val in [low, high]
+static inline bool in_range_inclusive(u32 val, u32 low, u32 high) {
+    return (val - low) <= (high - low);
+}
+
+static inline u32 parse_hex32(const char *begin, const char *end) {
+    u32 hex = 0;
+    for (const char *i = begin; i < end && i < begin + 8; ++i) {
+        int c = *i;
+        int current = 0;
+
+        const bool is_upper = in_range_inclusive(c, 'A', 'F');
+        current |= value_or_null(c - 'A' + 0xA, is_upper);
+
+        const bool is_lower = in_range_inclusive(c, 'a', 'f');
+        current |= value_or_null(c - 'a' + 0xA, is_lower);
+
+        const bool is_num = in_range_inclusive(c, '0', '9');
+        current |= value_or_null(c - '0', is_num);
+
+        // current & 0xf; we don't have to mask off, since we know it is either 0 or
+        // a valid number
+        hex = (hex << 4) | current;
+    }
+
+    return hex;
+}


### PR DESCRIPTION
Syncs settings with `config.ini` on the SD card and adds a `/set` debug command.

/set DriftMod Yes
```
[BaseSettings.c:18] Unknown key *::DriftMod
[BaseSettings.c:19] Expected one of:
[BaseSettings.c:30] DriftMode HudLabels FOV MapIcons Class GhostSorting TagVisibility TagContent SolidGhosts PageTransitions InputDisplay GhostSound 
```

/set DriftMode Yes
```
[BaseSettings.c:44] Unknown value "Yes" for Race::DriftMode
[BaseSettings.c:46] Expected one of:
[BaseSettings.c:48] - Manual (0)
[BaseSettings.c:48] - Auto (1)
```

/set DriftMode Manual
```
[BaseSettings.c:52] Setting Race::DriftMode to Manual (0)
```