### PR TITLE
Rewrite a code execution prevention function

### DIFF
--- a/payload/revolution/os/OSMemory.S
+++ b/payload/revolution/os/OSMemory.S
@@ -1,24 +1,6 @@
 #include <Common.S>
 #include <revolution/os.h>
 
-# Invalidate IBAT4
-PATCH_REPLACE_START(ConfigMEM2_56MB, 0x3C)
-    mtspr IBAT4L, r7
-    nop
-PATCH_REPLACE_END(ConfigMEM2_56MB, 0x3C)
-
-# Invalidate IBAT6
-PATCH_REPLACE_START(ConfigMEM2_56MB, 0x9C)
-    mtspr IBAT6L, r7
-    nop
-PATCH_REPLACE_END(ConfigMEM2_56MB, 0x9C)
-
-# Invalidate IBAT7
-PATCH_REPLACE_START(ConfigMEM2_56MB, 0xBC)
-    mtspr IBAT7L, r7
-    nop
-PATCH_REPLACE_END(ConfigMEM2_56MB, 0xBC)
-
 .globl DisableInstsOnMEM1Hi16MB
 DisableInstsOnMEM1Hi16MB:
     li        r0, 0
@@ -31,6 +13,25 @@ DisableInstsOnMEM1Hi16MB:
     mtspr     IBAT0U, r4
     mtspr     IBAT2U, r0
     mtspr     IBAT2L, r0
+    isync
+
+    mfmsr     r3
+    ori       r3, r3, MSR_DR | MSR_IR
+    mtspr     SRR1, r3
+    mfspr     r3, LR
+    mtspr     SRR0, r3
+    rfi
+
+.globl DisableInstsOnMEM2
+DisableInstsOnMEM2:
+    li        r0, 0
+
+    mtspr     IBAT4U, r0
+    mtspr     IBAT4L, r0
+    mtspr     IBAT6U, r0
+    mtspr     IBAT6L, r0
+    mtspr     IBAT7U, r0
+    mtspr     IBAT7L, r0
     isync
 
     mfmsr     r3

--- a/payload/revolution/os/OSMemory.c
+++ b/payload/revolution/os/OSMemory.c
@@ -2,6 +2,7 @@
 #include <sp/Payload.h>
 
 extern void DisableInstsOnMEM1Hi16MB(void);
+extern void DisableInstsOnMEM2(void);
 extern void EnableInstsOnPayload(void);
 
 void RealMode(void (*function)(void));
@@ -81,6 +82,16 @@ void OSDisableCodeExecOnMEM1Hi16MB(void) {
     BOOL enabled = OSDisableInterrupts();
     {
         RealMode(DisableInstsOnMEM1Hi16MB);
+    }
+    OSRestoreInterrupts(enabled);
+    // clang-format on
+}
+
+void OSDisableCodeExecOnMEM2(void) {
+    // clang-format off
+    BOOL enabled = OSDisableInterrupts();
+    {
+        RealMode(DisableInstsOnMEM2);
     }
     OSRestoreInterrupts(enabled);
     // clang-format on

--- a/payload/revolution/os/OSMemory.h
+++ b/payload/revolution/os/OSMemory.h
@@ -14,7 +14,8 @@
 #define OS_PROTECT_PERMISSION_WRITE 0x02
 #define OS_PROTECT_PERMISSION_RW    (OS_PROTECT_PERMISSION_READ | OS_PROTECT_PERMISSION_WRITE)
 
-void OSProtectRange(u32 channel, void* address, u32 size, u32 permissions);
+void OSProtectRange(u32 channel, void *address, u32 size, u32 permissions);
 
 void OSDisableCodeExecOnMEM1Hi16MB(void);
+void OSDisableCodeExecOnMEM2(void);
 void OSEnableCodeExecOnPayload(void);

--- a/payload/sp/Payload.cc
+++ b/payload/sp/Payload.cc
@@ -70,11 +70,12 @@ static void Init() {
     Console::Print("Applying security patches...");
 #ifndef GDB_COMPATIBLE
     OSDisableCodeExecOnMEM1Hi16MB();
+    OSDisableCodeExecOnMEM2();
     OSEnableCodeExecOnPayload();
 #endif
 
 #ifdef GDB_COMPATIBLE
-    OSSetMEM1ArenaLo((void*)0x809C4FA0);
+    OSSetMEM1ArenaLo((void *)0x809C4FA0);
 #else
     OSAllocFromMEM1ArenaLo(Rel_getSize(), 0x20);
 #endif
@@ -84,8 +85,10 @@ static void Init() {
     Heap_RandomizeMEM1Heaps();
     Heap_RandomizeMEM2Heaps();
 
-    Memory_ProtectRangeModule(OS_PROTECT_CHANNEL_1, Dol_getInitSectionStart(), Dol_getRodataSectionEnd(), OS_PROTECT_PERMISSION_READ);
-    Memory_ProtectRangeModule(OS_PROTECT_CHANNEL_2, Dol_getSdata2SectionStart(), Dol_getSbss2SectionEnd(), OS_PROTECT_PERMISSION_READ);
+    Memory_ProtectRangeModule(OS_PROTECT_CHANNEL_1, Dol_getInitSectionStart(),
+            Dol_getRodataSectionEnd(), OS_PROTECT_PERMISSION_READ);
+    Memory_ProtectRangeModule(OS_PROTECT_CHANNEL_2, Dol_getSdata2SectionStart(),
+            Dol_getSbss2SectionEnd(), OS_PROTECT_PERMISSION_READ);
     Console::Print(" done.\n");
 
     Console::Print("Initializing RTC...");

--- a/symbols.txt
+++ b/symbols.txt
@@ -259,7 +259,6 @@
 0x801a75d0 OSGetPhysicalMem1Size
 0x801a75dc OSGetPhysicalMem2Size
 0x801A7684 OSProtectRange
-0x801A792C ConfigMEM2_56MB
 0x801A7C94 RealMode
 0x801a7eac OSInitMutex
 0x801a7ee4 OSLockMutex


### PR DESCRIPTION
This commit rewrites the function that is responsible for marking the `MEM2` memory region as non-executable.