### PR TITLE
Implement __cxa_guard_acquire, __cxa_guard_release

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1276,6 +1276,7 @@ code_in_files = {
         os.path.join('payload', 'nw4r', 'snd', 'StrmFileReader.cc'),
         os.path.join('payload', 'nw4r', 'ut', 'FileStream.cc'),
         os.path.join('payload', 'nw4r', 'ut', 'IOStream.cc'),
+        os.path.join('payload', 'platform', 'guard.c'),
         os.path.join('payload', 'platform', 'string.c'),
         os.path.join('payload', 'platform', 'wchar.c'),
         os.path.join('payload', 'platform', 'wctype.c'),

--- a/payload/platform/guard.c
+++ b/payload/platform/guard.c
@@ -1,0 +1,22 @@
+// Reference: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#once-ctor
+
+#include <Common.h>
+#include <revolution.h>
+
+typedef struct {
+    u8 is_init; /* This byte must be here, the rest are free */
+    u8 _pad[3];
+
+    /* For now, just disable multitasking */
+    u32 msr_save;
+} sp_guard;
+static_assert(sizeof(sp_guard) == 8); /* As specified by ABI */
+
+int __cxa_guard_acquire(sp_guard *guard) {
+    guard->msr_save = OSDisableInterrupts();
+    return 1;
+}
+void __cxa_guard_release(sp_guard *guard) {
+    guard->is_init = 1;
+    OSRestoreInterrupts(guard->msr_save);
+}


### PR DESCRIPTION
C++11 guarantees function static variables are threadsafe; these helpers are the Itanium ABI's implementation detail. For now, just disable interrupts during initialization sequences.