### PR TITLE
Settings Clean Up

### DIFF
--- a/assets/message/MenuSP_E.bmg.json5
+++ b/assets/message/MenuSP_E.bmg.json5
@@ -389,7 +389,7 @@
     },
     "10133": {
         "font": "regular",
-        "string": "Let Stars, Mega Mushrooms and Lightnings affect the music.",
+        "string": "Let Stars, Mega Mushrooms and\nLightnings affect the music.",
     },
     "10134": {
         "font": "regular",

--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -1183,6 +1183,7 @@
         "font": "regular",
         "string": "Display your flag and region information in-game.",
     },
+    //Taken from Menu_U id 7253/7254, but had to duplicate because PAL changed the messages.
     //Region flag options
     "10337": {
         "font": "regular",

--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -1183,12 +1183,21 @@
         "font": "regular",
         "string": "Display your flag and region information in-game.",
     },
-    //Taken from Menu_U id 7253/7254, but had to duplicate because PAL changed the messages.
+    //Region flag options
     "10337": {
         "font": "regular",
         "string": "Don't Display",
     },
     "10338": {
+        "font": "regular",
+        "string": "Display",
+    },
+    //Performance Overlay Options
+    "10339": {
+        "font": "regular",
+        "string": "Don't Display",
+    },
+    "10340": {
         "font": "regular",
         "string": "Display",
     },

--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -445,7 +445,7 @@
     },
     "10133": {
         "font": "regular",
-        "string": "Let Stars, Mega Mushrooms and Lightnings affect the music.",
+        "string": "Let Stars, Mega Mushrooms and\nLightnings affect the music.",
     },
     "10134": {
         "font": "regular",
@@ -1145,7 +1145,7 @@
     },
     "10327": {
         "font": "regular",
-        "string": "Speedometer displays the internal speed of the vehicle plus moving road.",
+        "string": "Speedometer displays the internal speed\nof the vehicle plus moving road.",
     },
     "10328": {
         "font": "regular",
@@ -1157,11 +1157,11 @@
     },
     "10330": {
         "font": "regular",
-        "string": "Speedometer displays the speed the vehicle moves horizontally.",
+        "string": "Speedometer displays the speed\nthe vehicle moves horizontally.",
     },
     "10331": {
         "font": "regular",
-        "string": "Speedometer displays the speed the vehicle moves vertically.",
+        "string": "Speedometer displays the speed\nthe vehicle moves vertically.",
     },
     "10332": {
         "font": "regular",

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -448,13 +448,13 @@ const Entry entries[] = {
         .valueExplanationMessageIds = (u32[]) { 10059, 10060 },
     },
     [static_cast<u32>(Setting::PerfOverlay)] = {
-        .category = Category::License,
+        .category = Category::DebugOverlay,
         .name = magic_enum::enum_name(Setting::PerfOverlay),
         .messageId = 10188,
         .defaultValue = static_cast<u32>(PerfOverlay::Disable),
         .valueCount = magic_enum::enum_count<PerfOverlay>(),
         .valueNames = magic_enum::enum_names<PerfOverlay>().data(),
-        .valueMessageIds = (u32[]) { 10057, 10058 },
+        .valueMessageIds = (u32[]) { 10337, 10338 },
         .valueExplanationMessageIds = (u32[]) { 10189, 10190 },
     },
         [static_cast<u32>(Setting::RegionFlagDisplay)] = {


### PR DESCRIPTION
 - Added newlines to some of the speedometer option descriptions
- Added a new line to the "all" item music option description
- Performance overlay option moved to the "debug overlay" page, and given the "display/don't display" text