### PR TITLE
Rust CI

### DIFF
--- a/.github/workflows/build_sp.yml
+++ b/.github/workflows/build_sp.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build MKW-SP
 
 on: [push, pull_request]
 

--- a/.github/workflows/build_sp.yml
+++ b/.github/workflows/build_sp.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths-ignore:
       - tools/
+      - .github/workflows/build_tools.yml
   pull_request:
     paths-ignore:
       - tools/
+      - .github/workflows/build_tools.yml
 
 jobs:
   build:

--- a/.github/workflows/build_sp.yml
+++ b/.github/workflows/build_sp.yml
@@ -1,6 +1,12 @@
 name: Build MKW-SP
 
-on: [push, pull_request]
+on: 
+  push:
+    paths-ignore:
+      - tools/
+  pull_request:
+    paths-ignore:
+      - tools/
 
 jobs:
   build:

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -1,0 +1,33 @@
+on: [push, pull_request]
+
+name: Build Tools
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - netstorageserver
+          - portfinder
+          - updateserver
+          - sign
+        os:
+          - windows-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: false
+          command: build
+          args: --manifest-path tools/${{ matrix.tool }}/Cargo.toml --release
+      - name: Upload result
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.tool }}_${{ matrix.os }}
+          path: |
+            tools/${{ matrix.tool }}/target/release/${{ matrix.tool }}*
+            tools/${{ matrix.tool }}/target/release/${{ matrix.tool }}.d

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -24,13 +24,10 @@ jobs:
           - windows-latest
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
-    steps:
+    steps: 
       - uses: actions/checkout@v3
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: false
-          command: build
-          args: --manifest-path tools/${{ matrix.tool }}/Cargo.toml --release
+      - name: Build ${{ matrix.tool }}
+        run: cargo build --manifest-path tools/${{ matrix.tool }}/Cargo.toml --release
       - name: Upload result
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -2,9 +2,11 @@ on:
   push:
     paths:
       - tools/
+      - .github/workflows/build_tools.yml
   pull_request:
     paths:
       - tools/
+      - .github/workflows/build_tools.yml
 
 
 name: Build Tools

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -1,4 +1,11 @@
-on: [push, pull_request]
+on: 
+  push:
+    paths:
+      - tools/
+  pull_request:
+    paths:
+      - tools/
+
 
 name: Build Tools
 

--- a/tools/sign/Cargo.toml
+++ b/tools/sign/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 argon2 = { version = "0.4.0", features = ["std"] }
 libhydrogen = "0.4.1"
-passterm = "1.1.6"
+passterm = "1.1.7"
 zeroize = "1.5.5"

--- a/tools/updateserver/Cargo.toml
+++ b/tools/updateserver/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 argon2 = { version = "0.4.0", features = ["std"] }
 chrono = "0.4.19"
 libhydrogen = "0.4.1"
-passterm = "1.1.6"
+passterm = "1.1.7"
 prost = "0.10.4"
 tokio = { version = "1.19.2", features = ["rt-multi-thread", "io-util", "net", "sync", "fs"] }
 zeroize = "1.5.5"


### PR DESCRIPTION
This adds an action which build the rust tools, but only if the tools are modified. It also adds a filter to the trigger for the mod's action so that it does not build SP itself if a commit only changes the tools.

~~As of now, `sign` and `updateserver` fail to build as the `passterm` dependency fails to compile. I have not tested building them on a local machine, though, and so I do not know if the issue is with the CI or the dependency.~~ `passterm` has been updated, and both tools now compile.