### PR TITLE
gameserver: Implement start and voting logic

### DIFF
--- a/tools/gameserver/Cargo.toml
+++ b/tools/gameserver/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0.68"
 libhydrogen = "0.4"
 prost = "0.11"
+rand = "0.8.5"
 slab = "0.4.7"
 tokio = { version = "~1.20", features = ["rt-multi-thread", "io-util", "net", "macros", "sync"] }
 tracing = "0.1.37"

--- a/tools/gameserver/src/event.rs
+++ b/tools/gameserver/src/event.rs
@@ -1,4 +1,4 @@
-use crate::room_protocol::room_event::Event as RoomEvent;
+use crate::room_protocol::RoomEvent;
 
 /// The core of communication between MKW-SP and this server.
 #[derive(Clone, Debug)]

--- a/tools/gameserver/src/request.rs
+++ b/tools/gameserver/src/request.rs
@@ -15,6 +15,13 @@ pub enum Request {
     Comment {
         inner: room_event::Comment,
     },
+    Start {
+        gamemode: u8,
+    },
+    Vote {
+        player_id: u32,
+        properties: room_event::Properties,
+    },
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Gets clients in game, after roulette. This uses `RoomState` to make sure misbehaving clients cannot cause weirdness, ignoring requests at the wrong state.