### PR TITLE
Fix DPad input display in mirror mode

### DIFF
--- a/payload/game/ui/ctrl/CtrlRaceInputDisplay.cc
+++ b/payload/game/ui/ctrl/CtrlRaceInputDisplay.cc
@@ -100,22 +100,29 @@ void CtrlRaceInputDisplay::calcSelf() {
     }
 
     assert(input.trick < magic_enum::enum_count<DpadState>());
-    u8 dpad = std::min(static_cast<u8>(magic_enum::enum_count<DpadState>()), input.trick);
-    setDpad(static_cast<DpadState>(dpad));
+    assert(input.stick.x <= 1.0f && input.stick.x >= -1.0f);
+    assert(input.stick.y <= 1.0f && input.stick.y >= -1.0f);
 
+    auto dpad = static_cast<DpadState>(input.trick);
+
+    // Mirror mode inverts stick and dpad inputs
+    if (System::RaceConfig::Instance()->raceScenario().mirror) {
+        if (dpad == DpadState::Left) {
+            dpad = DpadState::Right;
+        } else if (dpad == DpadState::Right) {
+            dpad = DpadState::Left;
+        }
+
+        input.stick.x *= -1.0f;
+    }
+
+    setDpad(dpad);
     setAccel(input.accelerate ? AccelState::Pressed : AccelState::Off);
 
     bool l = input.item;
     setTrigger(Trigger::L, l ? TriggerState::Pressed : TriggerState::Off);
     bool r = input.brake || input.drift;
     setTrigger(Trigger::R, r ? TriggerState::Pressed : TriggerState::Off);
-
-    assert(input.stick.x <= 1.0f && input.stick.x >= -1.0f);
-    assert(input.stick.y <= 1.0f && input.stick.y >= -1.0f);
-    // Mirror mode inverts stick inputs
-    if (System::RaceConfig::Instance()->raceScenario().mirror) {
-        input.stick.x *= -1.0f;
-    }
     setStick(input.stick);
 
     if (speedModIsEnabled) {

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -326,8 +326,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(EngineClass::Mixed),
         .valueCount = magic_enum::enum_count<EngineClass>(),
         .valueNames = magic_enum::enum_names<EngineClass>().data(),
-        .valueMessageIds = (u32[]) { 10235, 10236, 10237, 10238, 10366, 10365 },
-        .valueExplanationMessageIds = (u32[]) { 10239, 10240, 10241, 10242, 10361, 10362 },
+        .valueMessageIds = (u32[]) { 10235, 10236, 10238, 10237, 10365, 10366 },
+        .valueExplanationMessageIds = (u32[]) { 10239, 10240, 10242, 10241, 10361, 10362 },
     },
     [static_cast<u32>(Setting::VSVehicles)] = {
         .category = Category::VS,
@@ -438,8 +438,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(EngineClass::Mixed),
         .valueCount = magic_enum::enum_count<EngineClass>(),
         .valueNames = magic_enum::enum_names<EngineClass>().data(),
-        .valueMessageIds = (u32[]) { 10235, 10236, 10237, 10238, 10366, 10365 },
-        .valueExplanationMessageIds = (u32[]) { 10239, 10240, 10241, 10242, 10361, 10362 },
+        .valueMessageIds = (u32[]) { 10235, 10236, 10238, 10237, 10365, 10366 },
+        .valueExplanationMessageIds = (u32[]) { 10239, 10240, 10242, 10241, 10361, 10362 },
     },
     [static_cast<u32>(Setting::RoomVehicles)] = {
         .category = Category::Room,


### PR DESCRIPTION
Fixes #501.

This also fixes the CC settings I broke during the battle mode PR, as I had mixed up message IDs.