### PR TITLE
Implement unverified device ID logins

### DIFF
--- a/payload/game/ui/RandomMatchingPage.cc
+++ b/payload/game/ui/RandomMatchingPage.cc
@@ -1,16 +1,12 @@
 #include "RandomMatchingPage.hh"
 
-#include <game/system/SaveManager.hh>
-#include <game/ui/SectionManager.hh>
-#include <sp/cs/RoomClient.hh>
+#include "game/system/SaveManager.hh"
+#include "game/ui/SectionManager.hh"
 
 #include <protobuf/Matchmaking.pb.h>
+#include <sp/cs/RoomClient.hh>
 #include <vendor/nanopb/pb_decode.h>
 #include <vendor/nanopb/pb_encode.h>
-
-extern "C" {
-#include <revolution/es.h>
-}
 
 namespace UI {
 

--- a/payload/game/ui/RandomMatchingPage.hh
+++ b/payload/game/ui/RandomMatchingPage.hh
@@ -27,6 +27,7 @@ private:
 
     void respondToLogin();
     void respondToChallenge(const STCMessage &event);
+    void respondToResponse(const STCMessage &event);
     void transitionToRoom(const STCMessage &event);
 
     PageInputManager m_inputManager;

--- a/payload/revolution/es.c
+++ b/payload/revolution/es.c
@@ -5,10 +5,19 @@
 #include <stdalign.h>
 
 enum {
+    IOCTLV_GETDEVICEID = 0x07,
     IOCTLV_SIGN = 0x30,
 };
 
 extern s32 es_fd;
+
+s32 ESP_GetDeviceId(u32 *deviceId) {
+    alignas(0x20) IOVector vec;
+    vec.data = deviceId;
+    vec.size = 4;
+
+    return IOS_Ioctlv(es_fd, IOCTLV_GETDEVICEID, 0, 1, &vec);
+}
 
 s32 ESP_Sign(const void *data, u32 size, u8 signature[0x3c], u8 certificate[0x180]) {
     if (!data != !size) {

--- a/payload/revolution/es.h
+++ b/payload/revolution/es.h
@@ -15,6 +15,7 @@ typedef struct {
 static_assert(sizeof(TmdView) == 0x205c);
 
 s32 ESP_InitLib();
+s32 ESP_GetDeviceId(u32 *deviceId);
 s32 ESP_GetTicketViews(u64 titleID, TicketView *views, u32 *count);
 s32 ESP_GetTmdView(u64 titleID, TmdView *view, u32 *size);
 s32 ESP_ListTitleContentsOnCard(u64 titleID, u32 *contentIds, u32 *count);

--- a/protobuf/Matchmaking.options
+++ b/protobuf/Matchmaking.options
@@ -1,1 +1,2 @@
-CTSMessage.LoginChallengeAnswer.challenge_signed max_length:512
+CTSMessage.LoginChallengeAnswer.challenge_signed max_size:512
+CTSMessage.LoginChallengeAnswer.mii              max_size:76

--- a/protobuf/Matchmaking.proto
+++ b/protobuf/Matchmaking.proto
@@ -55,6 +55,10 @@ message CTSMessage {
 
     message LoginChallengeAnswer {
         required bytes challenge_signed = 1;
+        required bytes mii              = 2;
+        required int32 location         = 3;
+        required int32 latitude         = 4;
+        required int32 longitude        = 5;
     }
 
     message StartMatchmaking {
@@ -82,7 +86,7 @@ message STCMessage {
     message LoginResponse {
         message Friend {
             required LoggedInId client_id     = 1;
-            required string     friend_suffix = 2;
+            required int32      friend_suffix = 2;
             required int32      location      = 3;
             required int32      latitude      = 4;
             required int32      longitude     = 5;

--- a/tools/matchmaking/Cargo.toml
+++ b/tools/matchmaking/Cargo.toml
@@ -19,6 +19,7 @@ libhydrogen = "0.4.1"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 sqlx = { version = "0.6.2", features = ["postgres", "runtime-tokio-native-tls", "offline"] }
 async-recursion = "1.0.2"
+rand = "0.8.5"
 
 [dependencies.netprotocol]
 path = "../netprotocol"

--- a/tools/matchmaking/migrations/20230203184635_device-id.sql
+++ b/tools/matchmaking/migrations/20230203184635_device-id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+    ALTER COLUMN friend_suffix TYPE smallint USING friend_suffix::smallint,
+    ALTER COLUMN race_rating SET DEFAULT 5000;

--- a/tools/matchmaking/sqlx-data.json
+++ b/tools/matchmaking/sqlx-data.json
@@ -16,7 +16,7 @@
         {
           "name": "friend_suffix",
           "ordinal": 2,
-          "type_info": "Text"
+          "type_info": "Int2"
         },
         {
           "name": "mii",
@@ -57,27 +57,6 @@
     },
     "query": "SELECT device_id, licence_id, friend_suffix, mii, location, latitude, longitude FROM users WHERE device_id = $1 AND licence_id = $2"
   },
-  "3c0084500cc7ac3dbab8c4a9654423992fb46752b15c260a977568be7b8a691b": {
-    "describe": {
-      "columns": [
-        {
-          "name": "race_rating",
-          "ordinal": 0,
-          "type_info": "Int4"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Int4",
-          "Int2"
-        ]
-      }
-    },
-    "query": "SELECT race_rating FROM users WHERE device_id = $1 AND licence_id = $2"
-  },
   "f1d76a01b8be0ce140b873ec8ce84ff9eadf1a908febe05c7ba6efa3db517e3f": {
     "describe": {
       "columns": [
@@ -104,5 +83,31 @@
       }
     },
     "query": "SELECT friendee_device_id, friendee_licence_id FROM friendships\n        WHERE friender_device_id = $1 AND friender_licence_id = $2"
+  },
+  "f87808cb42d814f99cc4cd331c1e33119d3dbcc64b022f8a052aa7447bf20526": {
+    "describe": {
+      "columns": [
+        {
+          "name": "race_rating",
+          "ordinal": 0,
+          "type_info": "Int4"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Int2",
+          "Bytea",
+          "Int2",
+          "Int4",
+          "Int4",
+          "Int4"
+        ]
+      }
+    },
+    "query": "\n            INSERT INTO\n                users(device_id, licence_id, mii, friend_suffix, location, latitude, longitude)\n            VALUES\n                ($1, $2, $3, $4, $5, $6, $7)\n            ON CONFLICT (device_id, licence_id) DO UPDATE SET\n                mii = $3,\n                location = $5,\n                latitude = $6,\n                longitude = $7\n            RETURNING race_rating\n        "
   }
 }

--- a/tools/matchmaking/src/tcp_forward.rs
+++ b/tools/matchmaking/src/tcp_forward.rs
@@ -52,7 +52,9 @@ impl ClientForwarder {
                     return;
                 };
 
-                if let Err(err) = Self::handle_connection(stream, logged_in_clients, db_pool, server).await {
+                if let Err(err) =
+                    Self::handle_connection(stream, logged_in_clients, db_pool, server).await
+                {
                     tracing::error!("Error in tcp connection handler: {err}")
                 };
             });


### PR DESCRIPTION
This implements the required IOS call to fetch the device ID, then sends this information to the matchmaking server if it is not the default dolphin ID.

On the server side, it adds a migration to the DB which sets up the schema better, to allow for user creation to actually occur (this was untested previously).

This PR does not verify if the console is lying about it's device ID, and is a foundation for this verification to be built on by someone other than me.