### PR TITLE
Implement FPS Mode setting

### DIFF
--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -1390,6 +1390,34 @@
         "font": "regular",
         "string": "Allow all files to be replaced.",
     },
+    "10386": {
+        "font": "regular",
+        "string": "FPS Mode",
+    },
+    "10387": {
+        "font": "regular",
+        "string": "Vanilla",
+    },
+    "10388": {
+        "font": "regular",
+        "string": "Force 60 FPS",
+    },
+    "10389": {
+        "font": "regular",
+        "string": "Force 30 FPS",
+    },
+    "10390": {
+        "font": "regular",
+        "string": "Uses 60fps, except for 3+ player splitscreen.",
+    },
+    "10391": {
+        "font": "regular",
+        "string": "Forces 60fps, even in 3+ player splitscreen.",
+    },
+    "10392": {
+        "font": "regular",
+        "string": "Forces 30fps, helps with Dolphin performance.",
+    },
     "20000": {
         "font": "regular",
         "string": "Online",

--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -1408,15 +1408,15 @@
     },
     "10390": {
         "font": "regular",
-        "string": "Uses 60fps, except for 3+ player splitscreen.",
+        "string": "Uses 60fps, except in intensive scenes.",
     },
     "10391": {
         "font": "regular",
-        "string": "Forces 60fps, even in 3+ player splitscreen.",
+        "string": "Forces 60fps, even in intensive scenes.",
     },
     "10392": {
         "font": "regular",
-        "string": "Forces 30fps, helps with Dolphin performance.",
+        "string": "Forces 30fps, can help with Dolphin performance.",
     },
     "20000": {
         "font": "regular",

--- a/configure.py
+++ b/configure.py
@@ -1421,6 +1421,7 @@ code_in_files = {
         os.path.join('payload', 'game', 'system', 'DvdArchive.c'),
         os.path.join('payload', 'game', 'system', 'DVDArchive.cc'),
         os.path.join('payload', 'game', 'system', 'FatalScene.c'),
+        os.path.join('payload', 'game', 'system', 'GameScene.cc'),
         os.path.join('payload', 'game', 'system', 'GhostFile.c'),
         os.path.join('payload', 'game', 'system', 'GhostFile.cc'),
         os.path.join('payload', 'game', 'system', 'GhostWriter.cc'),

--- a/payload/game/system/GameScene.cc
+++ b/payload/game/system/GameScene.cc
@@ -1,0 +1,26 @@
+#include "GameScene.hh"
+
+#include "game/system/SaveManager.hh"
+
+#include <sp/settings/ClientSettings.hh>
+
+extern "C" {
+#include <revolution.h>
+}
+
+namespace System {
+
+void GameScene::setFramerate(bool is_30) {
+    auto setting = SaveManager::Instance()->getSetting<SP::ClientSettings::Setting::FPSMode>();
+
+    switch (setting) {
+    case SP::ClientSettings::FPSMode::Vanilla:
+        return REPLACED(setFramerate)(is_30);
+    case SP::ClientSettings::FPSMode::Force60:
+        return REPLACED(setFramerate)(false);
+    case SP::ClientSettings::FPSMode::Force30:
+        return REPLACED(setFramerate)(true);
+    }
+}
+
+}

--- a/payload/game/system/GameScene.hh
+++ b/payload/game/system/GameScene.hh
@@ -29,6 +29,8 @@ public:
     virtual void vf_5c();
 
 private:
+    void REPLACED(setFramerate)(bool is_30);
+    REPLACE void setFramerate(bool is_30);
     u8 _0c70[0x2534 - 0x0c70];
 
 protected:

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -159,6 +159,17 @@ const Entry entries[] = {
         .valueExplanationMessageIds = (u32[]) { 10124, 10125 },
         .vanillaValue = static_cast<u32>(RankControl::GPVS),
     },
+    [static_cast<u32>(Setting::FPSMode)] = {
+        .category = Category::Race,
+        .name = magic_enum::enum_name(Setting::FPSMode),
+        .messageId = 10386,
+        .defaultValue = static_cast<u32>(FPSMode::Vanilla),
+        .valueCount = magic_enum::enum_count<FPSMode>(),
+        .valueNames = magic_enum::enum_names<FPSMode>().data(),
+        .valueMessageIds = (u32[]) { 10387, 10388, 10389 },
+        .valueExplanationMessageIds = (u32[]) { 10390, 10391, 10392 },
+        .vanillaValue = static_cast<u32>(FPSMode::Vanilla),
+    },
     [static_cast<u32>(Setting::Volume)] = {
         .category = Category::Sound,
         .name = magic_enum::enum_name(Setting::Volume),

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -20,6 +20,7 @@ enum class Setting {
     InputDisplay,
     Speedometer,
     RankControl,
+    FPSMode,
 
     // Sound
     Volume,
@@ -194,6 +195,12 @@ enum class Speedometer {
 enum class RankControl {
     GPVS,
     Always,
+};
+
+enum class FPSMode {
+    Vanilla,
+    Force60,
+    Force30,
 };
 
 enum class ItemMusic {
@@ -402,6 +409,11 @@ struct Helper<ClientSettings::Setting, ClientSettings::Setting::Speedometer> {
 template <>
 struct Helper<ClientSettings::Setting, ClientSettings::Setting::RankControl> {
     using type = SP::ClientSettings::RankControl;
+};
+
+template <>
+struct Helper<ClientSettings::Setting, ClientSettings::Setting::FPSMode> {
+    using type = SP::ClientSettings::FPSMode;
 };
 
 template <>

--- a/symbols.txt
+++ b/symbols.txt
@@ -487,6 +487,7 @@
 0x80519508 DvdArchive_decompress
 0x805195a4 DvdArchive_move
 0x805195d8 DvdArchive_loadOther
+0x8051af84 _ZN6System9GameScene12setFramerateEb
 0x8051bed0 GameScene_get
 0x8051c120 _ZN6System12RawGhostFile7IsValidEPKh
 0x8051c7f4 _ZN6System9GhostFile11writeHeaderEPNS_14RawGhostHeaderE


### PR DESCRIPTION
Replaces the setFramerate setting to allow users to either stay to vanilla, force 60fps, or force 30fps.

Resolves #546