### PR TITLE
Add /ui_info command

### DIFF
--- a/payload/egg/core/eggSystem.cc
+++ b/payload/egg/core/eggSystem.cc
@@ -1,9 +1,13 @@
 #include "eggSystem.hh"
+
 extern "C" {
 #include <revolution.h>
 }
 #include <sp/Commands.h>
 #include <sp/IOSDolphin.hh>
+#include <game/ui/SectionManager.hh>
+
+#include <cstring>
 
 namespace {
 
@@ -75,6 +79,12 @@ sp_define_command("/dolphin_test", "Test /dev/dolphin driver", const char *tmp) 
     DolphinTest();
 }
 } // namespace
+
+sp_define_command("/ui_info", "Dump information about the UI state to the console", const char *tmp) {
+    auto sectionManager = UI::SectionManager::Instance();
+    auto section = sectionManager->currentSection();
+    section->logDebuggingInfo(!strcmp(tmp, "/ui_info v"));
+}
 
 namespace EGG {
 

--- a/payload/game/ui/PageId.hh
+++ b/payload/game/ui/PageId.hh
@@ -90,7 +90,7 @@ enum class PageId {
     Confirm = 0x52,
     MessageBoardPopup = 0x53,
     Unknown54 = 0x54, // "Behind main menu?" however isn't activated on main menu.
-    Unknown55 = 0x55, // "Dummy? Goes to 0x5A" however is activated after 0x5A?
+    LowBatteryPopupManager = 0x55,
     LowBatteryPopup = 0x56,
     Title = 0x57,
     Unknown58 = 0x58, // "Behind main menu?" however isn't activated on main menu.

--- a/payload/game/ui/Section.cc
+++ b/payload/game/ui/Section.cc
@@ -452,7 +452,6 @@ bool Section::logPageInfo(Page *page) {
     return true;
 }
 
-extern "C" {
 void Section::logDebuggingInfo(bool verbose) {
     auto sectionManager = SectionManager::Instance();
     auto lastSectionId = sectionManager->nextSectionId();
@@ -481,7 +480,6 @@ void Section::logDebuggingInfo(bool verbose) {
     for (u16 i = 0; i < static_cast<u16>(PageId::Max); i += 1) {
         logPageInfo(m_pages[i]);
     }
-}
 }
 
 } // namespace UI

--- a/payload/game/ui/Section.cc
+++ b/payload/game/ui/Section.cc
@@ -1,5 +1,6 @@
 #include "Section.hh"
 
+#include "game/ui/SectionManager.hh"
 #include "game/ui/AwardPage.hh"
 #include "game/ui/ChannelPage.hh"
 #include "game/ui/CourseSelectPage.hh"
@@ -437,6 +438,50 @@ Page *Section::CreatePage(PageId pageId) {
     default:
         return REPLACED(CreatePage)(pageId);
     }
+}
+
+bool Section::logPageInfo(Page *page) {
+    if (page == nullptr) {
+        return false;
+    }
+
+    auto pageId = page->id();
+    auto pageName = magic_enum::enum_name<PageId>(pageId);
+
+    OSReport("    %s (0x%x)\n", pageName.data(), static_cast<u32>(pageId));
+    return true;
+}
+
+extern "C" {
+void Section::logDebuggingInfo(bool verbose) {
+    auto sectionManager = SectionManager::Instance();
+    auto lastSectionId = sectionManager->nextSectionId();
+    auto nextSectionId = sectionManager->nextSectionId();
+
+    auto sectionName = magic_enum::enum_name<SectionId>(m_id);
+    auto lastSectionName = magic_enum::enum_name<SectionId>(lastSectionId);
+    auto nextSectionName = magic_enum::enum_name<SectionId>(nextSectionId);
+
+    OSReport("Last Section: %s (0x%x)\n", lastSectionName.data(), static_cast<u32>(lastSectionId));
+    OSReport("Current Section: %s (0x%x)\n", sectionName.data(), static_cast<u32>(m_id));
+    OSReport("Next Section: %s (0x%x)\n", nextSectionName.data(), static_cast<u32>(nextSectionId));
+
+    OSReport("Active Pages:\n");
+    for (auto page : m_activePages) {
+        if (!logPageInfo(page)) {
+            break;
+        }
+    }
+
+    if (!verbose) {
+        return;
+    }
+
+    OSReport("Loaded Pages:\n");
+    for (u16 i = 0; i < static_cast<u16>(PageId::Max); i += 1) {
+        logPageInfo(m_pages[i]);
+    }
+}
 }
 
 } // namespace UI

--- a/payload/game/ui/Section.hh
+++ b/payload/game/ui/Section.hh
@@ -55,6 +55,8 @@ public:
     Vec2<f32> locationAdjustScale() const;
     void loadTHP();
 
+    void logDebuggingInfo(bool verbose);
+
     static u32 REPLACED(GetSceneId)(SectionId id);
     static REPLACE u32 GetSceneId(SectionId id);
     static const char *REPLACED(GetResourceName)(SectionId id);
@@ -75,6 +77,8 @@ private:
 
     static Page *REPLACED(CreatePage)(PageId pageId);
     static REPLACE Page *CreatePage(PageId pageId);
+
+    static bool logPageInfo(Page *page);
 
     SectionId m_id;
     u8 _004[0x008 - 0x004];


### PR DESCRIPTION
Adds a new command to the command system to dump information about the UI system, specifically current section, active pages, and optionally loaded pages.