### PR TITLE
Stub OnlineTopPage buttons in a more user friendly way

### DIFF
--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -1223,6 +1223,9 @@
     "20045": {
         string: "Speedometer does not display.",
     },
+    "20046": {
+        string: "This feature is currently under development.\nCheck back in a future update!",
+    },
     "30000": {
         string: "Your connection to the central server has been lost.",
     },

--- a/payload/game/ui/OnlineTopPage.cc
+++ b/payload/game/ui/OnlineTopPage.cc
@@ -2,7 +2,9 @@
 
 #include "game/ui/SectionManager.hh"
 #include "game/ui/SettingsPage.hh"
+#include "game/ui/MessagePage.hh"
 #include "game/ui/YesNoPage.hh"
+
 
 namespace UI {
 
@@ -97,12 +99,22 @@ void OnlineTopPage::onWorldwideButtonFront(PushButton* button, [[maybe_unused]] 
     startReplace(Anim::Next, button->getDelay());
 }
 
+void OnlineTopPage::showUnimplemented() {
+    auto section = SectionManager::Instance()->currentSection();
+    auto messagePopup = section->page<PageId::MessagePopup>();
+
+    messagePopup->reset();
+    messagePopup->setWindowMessage(20046);
+
+    push(PageId::MessagePopup, Anim::None);
+}
+
 void OnlineTopPage::onTrackpackButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
-    SP_LOG("OnlineTopPage::onTrackpackButtonFront");
+    showUnimplemented();
 }
 
 void OnlineTopPage::onFriendButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
-    SP_LOG("OnlineTopPage::onFriendButtonFront");
+    showUnimplemented();
 }
 
 void OnlineTopPage::onDirectButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {

--- a/payload/game/ui/OnlineTopPage.hh
+++ b/payload/game/ui/OnlineTopPage.hh
@@ -18,6 +18,8 @@ public:
     void onInit() override;
     void onActivate() override;
 private:
+    void showUnimplemented();
+
     void onBack(u32 localPlayerId);
     void onButtonSelect(PushButton *button, u32 localPlayerId);
     void onWorldwideButtonFront(PushButton *button, u32 localPlayerId);


### PR DESCRIPTION
This properly stubs the OnlineTopPage track pack and friends buttons while further development is done.