### PR TITLE
Avoid constructing invalid KartSaveState

### DIFF
--- a/payload/game/kart/KartSaveState.cc
+++ b/payload/game/kart/KartSaveState.cc
@@ -2,6 +2,10 @@
 
 namespace Kart {
 
+KartSaveState::KartSaveState(KartAccessor accessor, VehiclePhysics* physics) {
+    save(accessor, physics);
+}
+
 void KartSaveState::save(KartAccessor accessor, VehiclePhysics* physics) {
     m_physics = *physics;
     m_5c = *accessor.unk5c;

--- a/payload/game/kart/KartSaveState.hh
+++ b/payload/game/kart/KartSaveState.hh
@@ -32,7 +32,8 @@ struct KartTireFlat {
 
 class KartSaveState {
 public:
-    KartSaveState() = default;
+    KartSaveState() = delete;
+    KartSaveState(KartAccessor accessor, VehiclePhysics* physics);
 
     void save(KartAccessor accessor, VehiclePhysics* physics);
     void reload(KartAccessor accessor, VehiclePhysics* physics);

--- a/payload/game/kart/KartSaveState.hh
+++ b/payload/game/kart/KartSaveState.hh
@@ -32,7 +32,6 @@ struct KartTireFlat {
 
 class KartSaveState {
 public:
-    KartSaveState() = delete;
     KartSaveState(KartAccessor accessor, VehiclePhysics* physics);
 
     void save(KartAccessor accessor, VehiclePhysics* physics);

--- a/payload/sp/SaveStateManager.cc
+++ b/payload/sp/SaveStateManager.cc
@@ -39,18 +39,20 @@ auto SaveStateManager::GetKartState() {
 
 void SaveStateManager::save() {
     auto [accessor, physics] = GetKartState();
-    m_kartSaveState.save(accessor, physics);
-    m_hasSaved = true;
+    if (m_kartSaveState.has_value()) {
+        (*m_kartSaveState).save(accessor, physics);
+    } else {
+        m_kartSaveState.emplace(accessor, physics);
+    }
 }
 
 void SaveStateManager::reload() {
-    if (!m_hasSaved) {
+    if (m_kartSaveState.has_value()) {
+        auto [accessor, physics] = GetKartState();
+        (*m_kartSaveState).reload(accessor, physics);
+    } else {
         SP_LOG("SaveStateManager: Reload requested without save!");
-        return;
     }
-
-    auto [accessor, physics] = GetKartState();
-    m_kartSaveState.reload(accessor, physics);
 }
 
 void SaveStateManager::processInput(bool isPressed) {

--- a/payload/sp/SaveStateManager.cc
+++ b/payload/sp/SaveStateManager.cc
@@ -39,11 +39,7 @@ auto SaveStateManager::GetKartState() {
 
 void SaveStateManager::save() {
     auto [accessor, physics] = GetKartState();
-    if (m_kartSaveState.has_value()) {
-        (*m_kartSaveState).save(accessor, physics);
-    } else {
-        m_kartSaveState.emplace(accessor, physics);
-    }
+    m_kartSaveState.emplace(accessor, physics);
 }
 
 void SaveStateManager::reload() {

--- a/payload/sp/SaveStateManager.hh
+++ b/payload/sp/SaveStateManager.hh
@@ -2,6 +2,8 @@
 
 #include "game/kart/KartSaveState.hh"
 
+#include <optional>
+
 namespace SP {
 
 class SaveStateManager {
@@ -17,9 +19,8 @@ private:
     static auto GetKartState();
 
     u8 m_framesHeld = 0;
-    bool m_hasSaved = false;
+    std::optional<Kart::KartSaveState> m_kartSaveState = std::nullopt;
 
-    Kart::KartSaveState m_kartSaveState;
     static SaveStateManager* s_instance;
 };
 


### PR DESCRIPTION
Changes `KartSaveState`'s constructor to require the arguments to create a save state, avoiding the possibility of invalid junk state to be handled. This then uses std::optional in `SaveStateManager` to defer construction until the first save state is created.