### PR TITLE
Remove destructor override from OnlineConnectionManagerPage

### DIFF
--- a/payload/game/ui/OnlineConnectionManagerPage.cc
+++ b/payload/game/ui/OnlineConnectionManagerPage.cc
@@ -18,14 +18,6 @@ OnlineConnectionManagerPage::OnlineConnectionManagerPage() : m_socket{0x7F000001
     m_state = State::Initial;
 };
 
-void OnlineConnectionManagerPage::dt(s32 type) {
-    if (type > 0) {
-        delete this;
-    } else {
-        this->~OnlineConnectionManagerPage();
-    }
-}
-
 void OnlineConnectionManagerPage::onInit() {
     m_inputManager.init(0, false);
     setInputManager(&m_inputManager);

--- a/payload/game/ui/OnlineConnectionManagerPage.hh
+++ b/payload/game/ui/OnlineConnectionManagerPage.hh
@@ -20,9 +20,7 @@ public:
     };
 
     OnlineConnectionManagerPage();
-    ~OnlineConnectionManagerPage() override = default;
 
-    void dt(s32 type) override;
     void onInit() override;
     void afterCalc() override;
 


### PR DESCRIPTION
This PR closes #606, as the client automatically disconnects from matchmaking when transitioning out of the online section, meaning the page (and therefore `AsyncSocket` dtor) is called correctly.