### PR TITLE
Implement consistent style for declaring unused variables

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -66,6 +66,7 @@ typedef double f64;
         _a > _b ? _a : _b;      \
     })
 
+// Only for use in vendor code, we use `/* ... */` comments
 #define UNUSED(x) UNUSED_##x __attribute__((__unused__))
 
 #define CONTAINER_OF(ptr, type, member) \

--- a/include/Common.h
+++ b/include/Common.h
@@ -66,9 +66,6 @@ typedef double f64;
         _a > _b ? _a : _b;      \
     })
 
-// Only for use in vendor code, we use `/* ... */` comments
-#define UNUSED(x) UNUSED_##x __attribute__((__unused__))
-
 #define CONTAINER_OF(ptr, type, member) \
     ((type *)((char *)(1 ? (ptr) : &((type *)0)->member) - offsetof(type, member)))
 

--- a/loader/Apploader.cc
+++ b/loader/Apploader.cc
@@ -73,7 +73,7 @@ static std::optional<Partition> FindGamePartition(IOS::DI &di) {
     return {};
 }
 
-static void report(const char *UNUSED(format), ...) {}
+static void report(const char */* format */, ...) {}
 
 std::optional<GameEntryFunc> LoadAndRun(IOS::DI &di) {
     if (!di.readDiskID()) {

--- a/payload/egg/core/eggSystem.c
+++ b/payload/egg/core/eggSystem.c
@@ -186,7 +186,7 @@ static void my_lineCallback(const char *buf, size_t len) {
 // IOS KBD module is not supported on this platform
 static bool sConsoleInputUnavailable = false;
 
-void my_onBeginFrame(void *UNUSED(system)) {
+void my_onBeginFrame(void */* system */) {
     if (sItemSticky) {
         const s32 myPlayerId = GetMyPlayerID();
         if (myPlayerId >= 0) {

--- a/payload/egg/util/eggException.cc
+++ b/payload/egg/util/eggException.cc
@@ -23,7 +23,7 @@ static constexpr bool CheckCLStickThreshold(s16 stick) {
     return (stick >= 161 || stick <= -160);
 }
 
-bool ExceptionCallBack_(nw4r::db::ConsoleHandle console, void *UNUSED(arg)) {
+bool ExceptionCallBack_(nw4r::db::ConsoleHandle console, void */* arg */) {
     OSReport("CALLBACK...\n");
     if (!console) {
         OSReport("No Console\n");

--- a/payload/game/system/Console.c
+++ b/payload/game/system/Console.c
@@ -99,7 +99,7 @@ typedef struct {
     ScreenDrawData mScreen;
     void *mLastTexObj;
 } TextWriter;
-static void TextWriter_configure(TextWriter *self, Rect box, void *UNUSED(res)) {
+static void TextWriter_configure(TextWriter *self, Rect box, void */* res */) {
     self->mBox = WriterTextBox_create(box);
     self->mLastTexObj = NULL;
     ScreenDrawData_create(&self->mScreen);
@@ -123,7 +123,7 @@ static void TextWriter_beginDraw(TextWriter *self) {
     GXSetCullMode(GX_CULL_FRONT);
     GXSetAlphaCompare(GX_GREATER, 0, GX_AOP_AND, GX_ALWAYS, 0);
 }
-static void TextWriter_endDraw(TextWriter *UNUSED(writer)) {}
+static void TextWriter_endDraw(TextWriter */* writer */) {}
 enum {
     VERT_LEFT_X,
     VERT_RIGHT_X,
@@ -385,7 +385,7 @@ void Console_calc(void) {
     }
     Console_stateDefault(sFramesSinceLastOpen++);
 }
-void Console_addLine(const char *s, size_t UNUSED(len)) {
+void Console_addLine(const char *s, size_t /* len */) {
     // To support being called by an interrupt handler, we can't use a mutex. If a call
     // was interrupted, the global state could be accesesd in an invalid state.
     SP_SCOPED_NO_INTERRUPTS();

--- a/payload/game/system/DvdArchive.cc
+++ b/payload/game/system/DvdArchive.cc
@@ -16,7 +16,7 @@ extern "C" {
 namespace System {
 
 void DvdArchive::load(const char *path, EGG::Heap *archiveHeap, bool isCompressed, s8 align,
-        EGG::Heap *fileHeap, u32 UNUSED(unused)) {
+        EGG::Heap *fileHeap, u32) {
     if (m_state != State::Cleared) {
         return;
     }
@@ -34,7 +34,7 @@ void DvdArchive::load(const char *path, EGG::Heap *archiveHeap, bool isCompresse
     }
 }
 
-void DvdArchive::loadOther(DvdArchive *other, EGG::Heap *UNUSED(unused)) {
+void DvdArchive::loadOther(DvdArchive *other, EGG::Heap *) {
     if (m_state != State::Cleared || other->m_state != State::Mounted) {
         return;
     }

--- a/payload/game/system/DvdArchive.hh
+++ b/payload/game/system/DvdArchive.hh
@@ -18,8 +18,8 @@ public:
     void rip(const char *path, EGG::Heap *fileHeap, s8 align);
 
     REPLACE void load(const char *path, EGG::Heap *archiveHeap, bool isCompressed, s8 align,
-            EGG::Heap *fileHeap, u32 UNUSED(unused));
-    REPLACE void loadOther(DvdArchive *other, EGG::Heap *UNUSED(unused));
+            EGG::Heap *fileHeap, u32);
+    REPLACE void loadOther(DvdArchive *other, EGG::Heap *);
 
     void *REPLACED(getFile)(const char *path, size_t *size);
     REPLACE void *getFile(const char *path, size_t *size);

--- a/payload/game/system/FatalScene.c
+++ b/payload/game/system/FatalScene.c
@@ -106,7 +106,7 @@ static void setupCamera(lyt_DrawInfo *drawInfo, lyt_Layout *lyt) {
     drawInfo->viewRect = frame;
 }
 
-static void FatalScene_calc(EGGScene *UNUSED(scene)) {}
+static void FatalScene_calc(EGGScene */* scene */) {}
 static void FatalScene_draw(EGGScene *scene) {
     FatalScene *this = (FatalScene *)scene;
 
@@ -176,10 +176,10 @@ void FatalScene_SetBody(FatalScene *this, const wchar_t *body) {
     }
 }
 
-static void FatalScene_exit(EGGScene *UNUSED(scene)) {}
-static void FatalScene_reinit(EGGScene *UNUSED(scene)) {}
-static void FatalScene_incoming_childDestroy(EGGScene *UNUSED(scene)) {}
-static void FatalScene_outgoing_childCreate(EGGScene *UNUSED(scene)) {}
+static void FatalScene_exit(EGGScene */* scene */) {}
+static void FatalScene_reinit(EGGScene */* scene */) {}
+static void FatalScene_incoming_childDestroy(EGGScene */* scene */) {}
+static void FatalScene_outgoing_childCreate(EGGScene */* scene */) {}
 
 static void FatalScene_DTAdapater(EGGScene *scene, int type) {
     FatalScene_DT((FatalScene *)scene, type);
@@ -198,7 +198,7 @@ static EGGScene_Vtable sFatalScene_Vtable = (EGGScene_Vtable){
 
 static void PurgeHeap(MEMHeapHandle heap);
 
-static void free_all_visitor(void *block, MEMHeapHandle heap, u32 UNUSED(userParam)) {
+static void free_all_visitor(void *block, MEMHeapHandle heap, u32 /* userParam */) {
     for (MEMHeapHandle child = NULL; (child = MEMGetNextListObject(&heap->childList, child));) {
         PurgeHeap(child);
     }

--- a/payload/game/system/HomeButton.c
+++ b/payload/game/system/HomeButton.c
@@ -7,7 +7,7 @@
 void *HomeButton_getFile(void *r3, const char *path, EGG_Heap *heap, bool isCompressed,
         u32 *fileSize);
 
-static void *my_HomeButton_getFile(void *UNUSED(r3), const char *path, EGG_Heap *heap,
+static void *my_HomeButton_getFile(void */* r3 */, const char *path, EGG_Heap *heap,
         bool isCompressed, u32 *fileSize) {
     if (isCompressed) {
         u8 *file;

--- a/payload/game/system/MultiDvdArchive.hh
+++ b/payload/game/system/MultiDvdArchive.hh
@@ -22,7 +22,7 @@ public:
     virtual ~MultiDvdArchive();
 
     void clear();
-    void load(const char *path, EGG::Heap *archiveHeap, EGG::Heap *fileHeap, u32 UNUSED(unused));
+    void load(const char *path, EGG::Heap *archiveHeap, EGG::Heap *fileHeap, u32);
     void loadOther(MultiDvdArchive *other, EGG::Heap *heap);
 
     void setMission(u32 missionId);

--- a/payload/game/system/RaceManager.c
+++ b/payload/game/system/RaceManager.c
@@ -2,7 +2,7 @@
 
 #include "RaceConfig.h"
 
-static bool my_TimeAttackGameMode_canEndRace(TimeAttackGameMode *UNUSED(this)) {
+static bool my_TimeAttackGameMode_canEndRace(TimeAttackGameMode */* this */) {
     const RaceConfigScenario *raceScenario = &s_raceConfig->raceScenario;
     for (u32 i = 0; i < raceScenario->playerCount; i++) {
         if (!s_raceManager->players[i]->hasFinished) {

--- a/payload/game/system/SaveManager.cc
+++ b/payload/game/system/SaveManager.cc
@@ -59,7 +59,7 @@ void SaveManager::initAsync() {
     m_taskThread->request(InitTask, nullptr, nullptr);
 }
 
-void SaveManager::InitTask(void *UNUSED(arg)) {
+void SaveManager::InitTask(void */* arg */) {
     assert(s_instance);
     s_instance->init();
 }
@@ -100,7 +100,7 @@ void SaveManager::initGhostsAsync() {
     OSResumeThread(&m_ghostInitThread);
 }
 
-void *SaveManager::InitGhostsTask(void *UNUSED(arg)) {
+void *SaveManager::InitGhostsTask(void */* arg */) {
     assert(s_instance);
     s_instance->initGhosts();
     return nullptr;
@@ -206,7 +206,7 @@ void SaveManager::saveLicensesAsync() {
     m_taskThread->request(SaveSPSaveTask, nullptr, nullptr);
 }
 
-void SaveManager::SaveSPSaveTask(void *UNUSED(arg)) {
+void SaveManager::SaveSPSaveTask(void */* arg */) {
     assert(s_instance);
     s_instance->saveSPSave();
 }
@@ -368,12 +368,12 @@ GhostFooter *SaveManager::ghostFooter(u32 i) {
     return &m_ghostFooters[i];
 }
 
-void SaveManager::loadGhostHeadersAsync(s32 UNUSED(licenseId), GhostGroup *UNUSED(group)) {
+void SaveManager::loadGhostHeadersAsync(s32 /* licenseId */, GhostGroup */* group */) {
     m_isBusy = true;
     m_taskThread->request(LoadGhostHeadersTask, nullptr, nullptr);
 }
 
-void SaveManager::LoadGhostHeadersTask(void *UNUSED(arg)) {
+void SaveManager::LoadGhostHeadersTask(void */* arg */) {
     assert(s_instance);
     s_instance->loadGhostHeaders();
 }
@@ -387,13 +387,13 @@ void SaveManager::loadGhostHeaders() {
     m_result = NandResult::Ok;
 }
 
-void SaveManager::loadGhostAsync(s32 UNUSED(licenseId), u32 UNUSED(category), u32 UNUSED(index),
-        u32 UNUSED(courseId)) {
+void SaveManager::loadGhostAsync(s32 /* licenseId */, u32 /* category */, u32 /* index */,
+        u32 /* courseId */) {
     m_isBusy = true;
     m_taskThread->request(LoadGhostsTask, nullptr, nullptr);
 }
 
-void SaveManager::LoadGhostsTask(void *UNUSED(arg)) {
+void SaveManager::LoadGhostsTask(void */* arg */) {
     assert(s_instance);
     s_instance->loadGhosts();
 }
@@ -449,8 +449,8 @@ bool SaveManager::loadGhost(u32 i) {
     return RawGhostFile::IsValid((*menuScenario.ghostBuffer)[i], 0x2800);
 }
 
-void SaveManager::saveGhostAsync(s32 UNUSED(licenseId), u32 UNUSED(category), u32 UNUSED(index),
-        GhostFile *file, bool UNUSED(saveLicense)) {
+void SaveManager::saveGhostAsync(s32 /* licenseId */, u32 /* category */, u32 /* index */,
+        GhostFile *file, bool /* saveLicense */) {
     m_isBusy = true;
     m_taskThread->request(SaveGhostTask, file, nullptr);
 }

--- a/payload/game/system/SceneCreatorDynamic.c
+++ b/payload/game/system/SceneCreatorDynamic.c
@@ -2,7 +2,7 @@
 #include <revolution.h>
 #include "FatalScene.h"
 
-EGGScene *SceneCreatorDynamic_createOther(void *UNUSED(this), u32 sceneId) {
+EGGScene *SceneCreatorDynamic_createOther(void */* this */, u32 sceneId) {
     OSReport("SceneCreatorDynamic_createOther %u\n", sceneId);
 
     switch (sceneId) {

--- a/payload/game/ui/ChannelPage.cc
+++ b/payload/game/ui/ChannelPage.cc
@@ -274,7 +274,7 @@ void ChannelPage::transition(State state) {
     m_state = state;
 }
 
-void *ChannelPage::Install(void *UNUSED(arg)) {
+void *ChannelPage::Install(void */* arg */) {
     SP::Channel::Install();
     return nullptr;
 }

--- a/payload/game/ui/CourseSelectPage.cc
+++ b/payload/game/ui/CourseSelectPage.cc
@@ -164,12 +164,12 @@ u32 CourseSelectPage::lastSelected() const {
     return m_lastSelected;
 }
 
-void CourseSelectPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void CourseSelectPage::onBack(u32 /* localPlayerId */) {
     onBackCommon(0.0f);
 }
 
-void CourseSelectPage::onButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void CourseSelectPage::onButtonFront(PushButton * button,
+        u32 /* localPlayerId */) {
     u32 courseIndex = m_sheetIndex * m_buttons.size() + button->m_index;
     auto &entry = SP::CourseDatabase::Instance().entry(m_filter, courseIndex);
 
@@ -196,13 +196,13 @@ void CourseSelectPage::onButtonFront([[maybe_unused]] PushButton *button,
     }
 }
 
-void CourseSelectPage::onButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void CourseSelectPage::onButtonSelect(PushButton * button,
+        u32 /* localPlayerId */) {
     m_lastSelected = button->m_index;
 }
 
-void CourseSelectPage::onSheetSelectRight([[maybe_unused]] SheetSelectControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void CourseSelectPage::onSheetSelectRight(SheetSelectControl */* control */,
+        u32 /* localPlayerId */) {
     if (m_sheetIndex == m_sheetCount - 1) {
         m_sheetIndex = 0;
     } else {
@@ -220,8 +220,8 @@ void CourseSelectPage::onSheetSelectRight([[maybe_unused]] SheetSelectControl *c
     m_scrollBar.m_chosen = m_sheetIndex;
 }
 
-void CourseSelectPage::onSheetSelectLeft([[maybe_unused]] SheetSelectControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void CourseSelectPage::onSheetSelectLeft(SheetSelectControl */* control */,
+        u32 /* localPlayerId */) {
     if (m_sheetIndex == 0) {
         m_sheetIndex = m_sheetCount - 1;
     } else {
@@ -239,21 +239,21 @@ void CourseSelectPage::onSheetSelectLeft([[maybe_unused]] SheetSelectControl *co
     m_scrollBar.m_chosen = m_sheetIndex;
 }
 
-void CourseSelectPage::onScrollBarChange([[maybe_unused]] ScrollBar *scrollBar,
-        [[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 chosen) {
+void CourseSelectPage::onScrollBarChange(ScrollBar */* scrollBar */,
+        u32 /* localPlayerId */, u32 chosen) {
     m_sheetIndex = chosen;
 
     refresh();
 }
 
-void CourseSelectPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void CourseSelectPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     f32 delay = button->getDelay();
     onBackCommon(delay);
 }
 
-void CourseSelectPage::onBackConfirm([[maybe_unused]] s32 choice,
-        [[maybe_unused]] PushButton *button) {
+void CourseSelectPage::onBackConfirm(s32 /* choice */,
+        PushButton * /* button */) {
     m_backConfirmed = true;
 }
 

--- a/payload/game/ui/DirectConnectionPage.cc
+++ b/payload/game/ui/DirectConnectionPage.cc
@@ -110,7 +110,7 @@ void DirectConnectionPage::onActivate() {
     m_replacement = PageId::None;
 }
 
-void DirectConnectionPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void DirectConnectionPage::onBack(u32 /* localPlayerId */) {
     if (!m_editBox.isEmpty()) {
         m_editBox.remove();
         m_okButton.setPlayerFlags(0);
@@ -124,8 +124,8 @@ void DirectConnectionPage::onBack([[maybe_unused]] u32 localPlayerId) {
     startReplace(Anim::Prev, 0.0f);
 }
 
-void DirectConnectionPage::onDigitButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void DirectConnectionPage::onDigitButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_editBox.insert(button->m_index);
     if (m_editBox.isFull()) {
         m_okButton.setPlayerFlags(1);
@@ -133,19 +133,19 @@ void DirectConnectionPage::onDigitButtonFront([[maybe_unused]] PushButton *butto
     }
 }
 
-void DirectConnectionPage::onBackspaceButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void DirectConnectionPage::onBackspaceButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_editBox.remove();
     m_okButton.setPlayerFlags(0);
 }
 
-void DirectConnectionPage::onResetButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void DirectConnectionPage::onResetButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_editBox.reset();
     m_okButton.setPlayerFlags(0);
 }
 
-void DirectConnectionPage::onOkButtonFront(PushButton *button, [[maybe_unused]] u32 localPlayerId) {
+void DirectConnectionPage::onOkButtonFront(PushButton *button, u32 /* localPlayerId */) {
     u64 directCode = m_editBox.getNumber();
     if (directCode == 0) {
         m_replacement = PageId::RandomMatching;
@@ -178,13 +178,13 @@ void DirectConnectionPage::onOkButtonFront(PushButton *button, [[maybe_unused]] 
 }
 
 void DirectConnectionPage::onBackButtonFront(PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+        u32 /* localPlayerId */) {
     m_replacement = PageId::OnlineTop;
     f32 delay = button->getDelay();
     startReplace(Anim::Prev, delay);
 }
 
-void DirectConnectionPage::onBadConnectCode([[maybe_unused]] MessagePage *messagePage) {
+void DirectConnectionPage::onBadConnectCode(MessagePage *messagePage) {
     reinterpret_cast<MenuMessagePage *>(messagePage)->m_replacement = PageId::OnlineTop;
 }
 

--- a/payload/game/ui/FriendMatchingPage.cc
+++ b/payload/game/ui/FriendMatchingPage.cc
@@ -125,7 +125,7 @@ void FriendMatchingPage::prepareStartClient() {
     m_roomStarted = true;
 }
 
-void FriendMatchingPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void FriendMatchingPage::onBack(u32 /* localPlayerId */) {
     auto *roomManager = SP::RoomManager::Instance();
     if (roomManager) {
         roomManager->destroyInstance();
@@ -180,7 +180,7 @@ void FriendMatchingPage::Handler::onSelect() {
 }
 
 void FriendMatchingPage::Handler::onPlayerJoin(const System::RawMii *mii, u32 location,
-        u16 latitude, u16 longitude, u32 UNUSED(regionLineColor)) {
+        u16 latitude, u16 longitude, u32 /* regionLineColor */) {
     Section *section = SectionManager::Instance()->currentSection();
     auto *friendRoomBackPage = section->page<PageId::FriendRoomBack>();
     friendRoomBackPage->onPlayerJoin(*mii, location, latitude, longitude);

--- a/payload/game/ui/FriendRoomMessageSelectPage.cc
+++ b/payload/game/ui/FriendRoomMessageSelectPage.cc
@@ -152,15 +152,15 @@ void FriendRoomMessageSelectPage::refresh() {
     }
 }
 
-void FriendRoomMessageSelectPage::onBackButtonFront([[maybe_unused]] PushButton *button, [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomMessageSelectPage::onBackButtonFront(PushButton * /* button */, u32 /* localPlayerId */) {
     startReplace(Anim::Prev, 0.0f);
 }
 
-void FriendRoomMessageSelectPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void FriendRoomMessageSelectPage::onBack(u32 /* localPlayerId */) {
     startReplace(Anim::Prev, 0.0f);
 }
 
-void FriendRoomMessageSelectPage::onCommentButtonFront(PushButton *button, [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomMessageSelectPage::onCommentButtonFront(PushButton *button, u32 /* localPlayerId */) {
     m_cachedSheetIdx = m_currentSheetIdx;
     m_cachedButton = button->m_index;
 
@@ -169,12 +169,12 @@ void FriendRoomMessageSelectPage::onCommentButtonFront(PushButton *button, [[may
     startReplace(Anim::Next, button->getDelay());
 }
 
-void FriendRoomMessageSelectPage::onStartButtonFront(PushButton *button, [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomMessageSelectPage::onStartButtonFront(PushButton *button, u32 /* localPlayerId */) {
     SP::RoomClient::Instance()->startRoom(button->m_index);
     startReplace(Anim::Next, button->getDelay());
 }
 
-void FriendRoomMessageSelectPage::onRight([[maybe_unused]] SheetSelectControl *control, [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomMessageSelectPage::onRight(SheetSelectControl */* control */, u32 /* localPlayerId */) {
     if (!m_visibleMessageSelect->isShown() || !m_hiddenMessageSelect->isHidden()) { return; }
 
     m_visibleMessageSelect->slideOut(true);
@@ -187,7 +187,7 @@ void FriendRoomMessageSelectPage::onRight([[maybe_unused]] SheetSelectControl *c
     m_visibleMessageSelect->slideIn(true);
 }
 
-void FriendRoomMessageSelectPage::onLeft([[maybe_unused]] SheetSelectControl *control, [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomMessageSelectPage::onLeft(SheetSelectControl */* control */, u32 /* localPlayerId */) {
     if (!m_visibleMessageSelect->isShown() || !m_hiddenMessageSelect->isHidden()) { return; }
 
     m_visibleMessageSelect->slideOut(false);

--- a/payload/game/ui/FriendRoomPage.cc
+++ b/payload/game/ui/FriendRoomPage.cc
@@ -123,7 +123,7 @@ void FriendRoomPage::pop(Anim anim) {
     m_popRequested = true;
 }
 
-void FriendRoomPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onBack(u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *yesNoPage = section->page<PageId::YesNoPopup>();
 
@@ -134,8 +134,8 @@ void FriendRoomPage::onBack([[maybe_unused]] u32 localPlayerId) {
     push(PageId::YesNoPopup, Anim::Next);
 }
 
-void FriendRoomPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onSettingsButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(0);
 
     auto *section = SectionManager::Instance()->currentSection();
@@ -144,8 +144,8 @@ void FriendRoomPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
     push(PageId::SettingsPopup, Anim::Next);
 }
 
-void FriendRoomPage::onCommentButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onCommentButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *messageSelectPage = section->page<PageId::FriendRoomMessageSelect>();
     messageSelectPage->setMenuType(FriendRoomMessageSelectPage::MenuType::Comment);
@@ -154,13 +154,13 @@ void FriendRoomPage::onCommentButtonFront([[maybe_unused]] PushButton *button,
     m_instructionText.setMessage(4371, 0);
 }
 
-void FriendRoomPage::onRulesButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onRulesButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     push(PageId::FriendRoomRules, Anim::Next);
 }
 
-void FriendRoomPage::onStartButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onStartButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *messageSelectPage = section->page<PageId::FriendRoomMessageSelect>();
     messageSelectPage->setMenuType(FriendRoomMessageSelectPage::MenuType::Start);
@@ -169,11 +169,11 @@ void FriendRoomPage::onStartButtonFront([[maybe_unused]] PushButton *button,
     m_instructionText.setMessage(4373, 0);
 }
 
-void FriendRoomPage::onRegisterButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {}
+void FriendRoomPage::onRegisterButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {}
 
-void FriendRoomPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onBackButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *yesNoPage = section->page<PageId::YesNoPopup>();
 
@@ -184,20 +184,20 @@ void FriendRoomPage::onBackButtonFront([[maybe_unused]] PushButton *button,
     push(PageId::YesNoPopup, Anim::Next);
 }
 
-void FriendRoomPage::onButtonSelect(PushButton *button, [[maybe_unused]] u32 localPlayerId) {
+void FriendRoomPage::onButtonSelect(PushButton *button, u32 /* localPlayerId */) {
     m_instructionText.setMessage(button->m_index, nullptr);
 }
 
-void FriendRoomPage::onBackConfirm([[maybe_unused]] s32 choice,
-        [[maybe_unused]] PushButton *button) {
+void FriendRoomPage::onBackConfirm(s32 /* choice */,
+        PushButton * /* button */) {
     SP::RoomManager::Instance()->destroyInstance();
     auto *section = SectionManager::Instance()->currentSection();
     auto *friendMatchingPage = section->page<PageId::FriendMatching>();
     friendMatchingPage->collapse(Anim::Prev);
 }
 
-void FriendRoomPage::onSettingsBack([[maybe_unused]] SettingsPage *settingsPage,
-        [[maybe_unused]] PushButton *button) {
+void FriendRoomPage::onSettingsBack(SettingsPage */* settingsPage */,
+        PushButton * /* button */) {
     m_instructionText.setMessage(20022);
 
     if (auto *client = SP::RoomClient::Instance()) {

--- a/payload/game/ui/FriendRoomRulesPage.cc
+++ b/payload/game/ui/FriendRoomRulesPage.cc
@@ -86,7 +86,7 @@ void FriendRoomRulesPage::refresh(const std::array<u32, SP::RoomSettings::count>
     }
 }
 
-void FriendRoomRulesPage::onFront([[maybe_unused]] u32 localPlayerId) {
+void FriendRoomRulesPage::onFront(u32 /* localPlayerId */) {
     startReplace(Anim::None, 0.0f);
 }
 

--- a/payload/game/ui/GhostManagerPage.cc
+++ b/payload/game/ui/GhostManagerPage.cc
@@ -9,7 +9,7 @@
 
 namespace UI {
 
-void GhostManagerPage::List::populate(u32 UNUSED(courseId)) {}
+void GhostManagerPage::List::populate(u32 /* courseId */) {}
 
 void GhostManagerPage::SPList::populate() {
     auto *saveManager = System::SaveManager::Instance();
@@ -115,11 +115,11 @@ const GhostManagerPage::SPList *GhostManagerPage::list() const {
     return &m_list;
 }
 
-void GhostManagerPage::setupGhostReplay(bool UNUSED(isStaffGhost)) {
+void GhostManagerPage::setupGhostReplay(bool /* isStaffGhost */) {
     setupTimeAttack(false, false);
 }
 
-void GhostManagerPage::setupGhostRace(bool UNUSED(isStaffGhost), bool UNUSED(isNewRecord),
+void GhostManagerPage::setupGhostRace(bool /* isStaffGhost */, bool /* isNewRecord */,
         bool fromReplay) {
     setupTimeAttack(true, fromReplay);
 }

--- a/payload/game/ui/GhostSelectButton.cc
+++ b/payload/game/ui/GhostSelectButton.cc
@@ -54,14 +54,14 @@ TimeAttackGhostListPage *GhostSelectButton::getGhostListPage() {
     return reinterpret_cast<TimeAttackGhostListPage *>(UIControl::getPage());
 }
 
-void GhostSelectButton::onSelect([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {
+void GhostSelectButton::onSelect(u32 localPlayerId, u32 /* r5 */) {
     OptionButton::onSelect(localPlayerId);
 
     TimeAttackGhostListPage *page = getGhostListPage();
     page->m_lastSelected = m_index;
 }
 
-void GhostSelectButton::onFront([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {
+void GhostSelectButton::onFront(u32 /* localPlayerId */, u32 /* r5 */) {
     m_animator.setAnimation(GROUP_ID_SELECT_IN, ANIM_ID_SELECT_IN, 0.0f);
     m_animator.setAnimation(GROUP_ID_OK, ANIM_ID_OK, 0.0f);
 

--- a/payload/game/ui/License.c
+++ b/payload/game/ui/License.c
@@ -8,7 +8,7 @@ static_assert(sizeof(LicenseControl) == 0x174);
 void refreshLicenseControl(void *r3, LicenseControl *control, u32 licenseId, MiiGroup *miiGroup,
         u32 index);
 
-void my_refreshLicenseControl(void *UNUSED(r3), LicenseControl *control, u32 UNUSED(licenseId),
+void my_refreshLicenseControl(void */* r3 */, LicenseControl *control, u32 /* licenseId */,
         MiiGroup *miiGroup, u32 index) {
     LayoutUIControl_setPaneVisible(control, "new", false);
     LayoutUIControl_setPaneVisible(control, "mii", true);

--- a/payload/game/ui/LicenseSelectPage.cc
+++ b/payload/game/ui/LicenseSelectPage.cc
@@ -78,23 +78,23 @@ void LicenseSelectPage::onActivate() {
     m_replacement = PageId::None;
 }
 
-void LicenseSelectPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void LicenseSelectPage::onBack(u32 /* localPlayerId */) {
     System::SaveManager::Instance()->unselectSPLicense();
 
     m_replacement = PageId::Title;
     startReplace(Anim::Prev, 0.0f);
 }
 
-void LicenseSelectPage::onServicePackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void LicenseSelectPage::onServicePackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     System::SaveManager::Instance()->unselectSPLicense();
 
     f32 delay = button->getDelay();
     changeSection(SectionId::ServicePack, Anim::Next, delay);
 }
 
-void LicenseSelectPage::onLicenseButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void LicenseSelectPage::onLicenseButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     System::SaveManager *saveManager = System::SaveManager::Instance();
     SectionManager *sectionManager = SectionManager::Instance();
     GlobalContext *globalContext = sectionManager->globalContext();
@@ -137,8 +137,8 @@ void LicenseSelectPage::onLicenseButtonFront([[maybe_unused]] PushButton *button
     }
 }
 
-void LicenseSelectPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void LicenseSelectPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     System::SaveManager::Instance()->unselectSPLicense();
 
     m_replacement = PageId::Title;
@@ -146,22 +146,22 @@ void LicenseSelectPage::onBackButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Prev, delay);
 }
 
-void LicenseSelectPage::onCreateConfirm([[maybe_unused]] ConfirmPage *confirmPage,
-        [[maybe_unused]] f32 delay) {
+void LicenseSelectPage::onCreateConfirm(ConfirmPage */* confirmPage */,
+        f32 delay) {
     SectionManager *sectionManager = SectionManager::Instance();
     sectionManager->setNextSection(SectionId::MiiSelectCreate, Anim::Next);
     sectionManager->startChangeSection(delay, 0x000000ff);
 }
 
-void LicenseSelectPage::onChangeConfirm([[maybe_unused]] ConfirmPage *confirmPage,
-        [[maybe_unused]] f32 delay) {
+void LicenseSelectPage::onChangeConfirm(ConfirmPage */* confirmPage */,
+        f32 delay) {
     SectionManager *sectionManager = SectionManager::Instance();
     sectionManager->setNextSection(SectionId::MiiSelectChange, Anim::Next);
     sectionManager->startChangeSection(delay, 0x000000ff);
 }
 
-void LicenseSelectPage::onCancel([[maybe_unused]] ConfirmPage *confirmPage,
-        [[maybe_unused]] f32 delay) {
+void LicenseSelectPage::onCancel(ConfirmPage *confirmPage,
+        f32 /* delay */) {
     confirmPage->m_replacement = PageId::LicenseSelect;
 }
 

--- a/payload/game/ui/Map2DRenderer.c
+++ b/payload/game/ui/Map2DRenderer.c
@@ -15,7 +15,7 @@ extern int Map2DRenderer_init__createTexBuffer;
 
 extern void* EGG_CpuTexture_Construct(void* self, short width, short height, GXTexFmt format);
 
-static GXTexFmt GetMinimapTextureFormat(GXTexFmt UNUSED(oldFormat)) {
+static GXTexFmt GetMinimapTextureFormat(GXTexFmt /* oldFormat */) {
     return (GXTexFmt)kMinimapFormats_Override;
 }
 

--- a/payload/game/ui/MultiTeamSelectPage.cc
+++ b/payload/game/ui/MultiTeamSelectPage.cc
@@ -139,7 +139,7 @@ void MultiTeamSelectPage::onRefocus() {
     }
 }
 
-void MultiTeamSelectPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void MultiTeamSelectPage::onBack(u32 localPlayerId) {
     if (!m_teamControls[localPlayerId].m_enabled) {
         m_teamControls[localPlayerId].m_enabled = true;
 
@@ -165,8 +165,8 @@ void MultiTeamSelectPage::onBack([[maybe_unused]] u32 localPlayerId) {
     startReplace(Anim::Prev, 0.0f);
 }
 
-void MultiTeamSelectPage::onTeamControlFront([[maybe_unused]] UpDownControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTeamSelectPage::onTeamControlFront(UpDownControl *control,
+        u32 localPlayerId) {
     auto *driverModelManager = MenuModelManager::Instance()->driverModelManager();
     if (control->m_enabled) {
         control->m_enabled = false;
@@ -221,15 +221,15 @@ void MultiTeamSelectPage::onTeamControlFront([[maybe_unused]] UpDownControl *con
 }
 
 void MultiTeamSelectPage::onTeamValueChange(
-        [[maybe_unused]] TextUpDownValueControl::TextControl *text, [[maybe_unused]] u32 index) {
+        TextUpDownValueControl::TextControl *text, u32 index) {
     text->setMessageAll(10268 + index);
     char flagPane[0x20];
     snprintf(flagPane, std::size(flagPane), "flag_%u", index);
     text->setPicture("flag_set_p", flagPane);
 }
 
-void MultiTeamSelectPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTeamSelectPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *context = SectionManager::Instance()->globalContext();
     u32 localPlayerCount = context->m_localPlayerCount;
     auto *driverModelManager = MenuModelManager::Instance()->driverModelManager();

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -81,15 +81,15 @@ void MultiTopPage::onActivate() {
     }
 }
 
-void MultiTopPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onBack(u32 /* localPlayerId */) {
     m_reset = true;
 
     m_replacement = PageId::ControllerBoxes;
     startReplace(Anim::Next, 0.0f);
 }
 
-void MultiTopPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onSettingsButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *menuSettingsPage = section->page<PageId::MenuSettings>();
     menuSettingsPage->configure(nullptr, PageId::MultiTop);
@@ -98,13 +98,13 @@ void MultiTopPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void MultiTopPage::onSettingsButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onSettingsButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(10077);
 }
 
-void MultiTopPage::onVSButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onVSButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *saveManager = System::SaveManager::Instance();
     auto teamsizeSetting = saveManager->getSetting<SP::ClientSettings::Setting::VSTeamSize>();
     u32 maxTeamSize = teamsizeSetting == SP::ClientSettings::TeamSize::Six ? 6 :
@@ -136,8 +136,8 @@ void MultiTopPage::onVSButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void MultiTopPage::onVSButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onVSButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(3052);
 
     Section *section = SectionManager::Instance()->currentSection();
@@ -145,8 +145,8 @@ void MultiTopPage::onVSButtonSelect([[maybe_unused]] PushButton *button,
     modelPage->modelControl().setModel(2);
 }
 
-void MultiTopPage::onBTButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onBTButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *saveManager = System::SaveManager::Instance();
     auto *context = SectionManager::Instance()->globalContext();
     context->m_matchCount = saveManager->getSetting<SP::ClientSettings::Setting::BTRaceCount>();
@@ -178,8 +178,8 @@ void MultiTopPage::onBTButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void MultiTopPage::onBTButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onBTButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(3054);
 
     Section *section = SectionManager::Instance()->currentSection();
@@ -187,8 +187,8 @@ void MultiTopPage::onBTButtonSelect([[maybe_unused]] PushButton *button,
     modelPage->modelControl().setModel(3);
 }
 
-void MultiTopPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_reset = true;
 
     m_replacement = PageId::ControllerBoxes;
@@ -196,8 +196,8 @@ void MultiTopPage::onBackButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Prev, delay);
 }
 
-void MultiTopPage::onBackButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiTopPage::onBackButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(0);
 }
 

--- a/payload/game/ui/OnlineConnectionManagerPage.cc
+++ b/payload/game/ui/OnlineConnectionManagerPage.cc
@@ -119,7 +119,7 @@ void OnlineConnectionManagerPage::startLogin() {
     write(response);
 }
 
-void OnlineConnectionManagerPage::respondToChallenge(const STCMessage &event) {
+void OnlineConnectionManagerPage::respondToChallenge(const STCMessage &/* event */) {
     CTSMessage response;
     u16 longitude;
     u16 latitude;

--- a/payload/game/ui/OnlineTeamSelectPage.cc
+++ b/payload/game/ui/OnlineTeamSelectPage.cc
@@ -100,17 +100,17 @@ void OnlineTeamSelectPage::onReceiveTeamSelect(u32 playerId, u32 teamId) {
     }
 }
 
-void OnlineTeamSelectPage::onBack([[maybe_unused]] u32 localPlayerId) {}
+void OnlineTeamSelectPage::onBack(u32 /* localPlayerId */) {}
 
-void OnlineTeamSelectPage::onButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void OnlineTeamSelectPage::onButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     u32 playerId = button->m_index;
     auto *roomClient = SP::RoomClient::Instance();
     roomClient->sendTeamSelect(playerId);
     m_buttons[playerId].refresh(roomClient->player(playerId).m_teamId);
 }
 
-void OnlineTeamSelectPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {}
+void OnlineTeamSelectPage::onBackButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {}
 
 } // namespace UI

--- a/payload/game/ui/OnlineTopPage.cc
+++ b/payload/game/ui/OnlineTopPage.cc
@@ -81,16 +81,16 @@ void OnlineTopPage::onActivate() {
     }
 }
 
-void OnlineTopPage::onBack(u32 localPlayerId) {
+void OnlineTopPage::onBack(u32 /* localPlayerId */) {
     m_replacement = PageId::None;
     push(PageId::WifiDisconnect, Anim::None);
 }
 
-void OnlineTopPage::onButtonSelect(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
+void OnlineTopPage::onButtonSelect(PushButton* button, u32 /* localPlayerId */) {
     m_instructionText.setMessage(4310 + button->m_index);
 }
 
-void OnlineTopPage::onWorldwideButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
+void OnlineTopPage::onWorldwideButtonFront(PushButton* button, u32 /* localPlayerId */) {
     auto section = SectionManager::Instance()->currentSection();
     auto connectionManager = section->page<PageId::OnlineConnectionManager>();
     connectionManager->setTrackpack(0);
@@ -109,15 +109,15 @@ void OnlineTopPage::showUnimplemented() {
     push(PageId::MessagePopup, Anim::None);
 }
 
-void OnlineTopPage::onTrackpackButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
+void OnlineTopPage::onTrackpackButtonFront(PushButton* /* button */, u32 /* localPlayerId */) {
     showUnimplemented();
 }
 
-void OnlineTopPage::onFriendButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
+void OnlineTopPage::onFriendButtonFront(PushButton* /* button */, u32 /* localPlayerId */) {
     showUnimplemented();
 }
 
-void OnlineTopPage::onDirectButtonFront(PushButton* button, [[maybe_unused]] u32 localPlayerId) {
+void OnlineTopPage::onDirectButtonFront(PushButton* /* button */, u32 /* localPlayerId */) {
     auto section = SectionManager::Instance()->currentSection();
     auto confirmPopup = section->page<PageId::YesNoPopup>();
 
@@ -129,7 +129,7 @@ void OnlineTopPage::onDirectButtonFront(PushButton* button, [[maybe_unused]] u32
     push(PageId::YesNoPopup, Anim::Next);
 }
 
-void OnlineTopPage::onBackButtonFront([[maybe_unused]] PushButton* button, u32 localPlayerId) {
+void OnlineTopPage::onBackButtonFront(PushButton* /* button */, u32 localPlayerId) {
     onBack(localPlayerId);
 }
 

--- a/payload/game/ui/ScrollBar.cc
+++ b/payload/game/ui/ScrollBar.cc
@@ -149,7 +149,7 @@ void ScrollBar::reconfigure(u32 count, u32 chosen, u32 playerFlags) {
     setPlayerFlags(playerFlags);
 }
 
-void ScrollBar::onSelect([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {
+void ScrollBar::onSelect(u32 localPlayerId, u32 /* r5 */) {
     auto *group = m_animator.getGroup(GroupId::Select);
     if (group->getAnimation() == AnimId::Select::Free) {
         group->setAnimation(AnimId::Select::FreeToSelect, 0.0f);
@@ -168,7 +168,7 @@ void ScrollBar::onSelect([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u3
     playSound(Sound::SoundId::SE_UI_UD_IN, localPlayerId);
 }
 
-void ScrollBar::onDeselect([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {
+void ScrollBar::onDeselect(u32 /* localPlayerId */, u32 /* r5 */) {
     auto *group = m_animator.getGroup(GroupId::Select);
     if (group->getAnimation() == AnimId::Select::Select) {
         group->setAnimation(AnimId::Select::SelectToFree, 0.0f);
@@ -181,7 +181,7 @@ void ScrollBar::onDeselect([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] 
     m_sequence.reset();
 }
 
-void ScrollBar::onFront([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {
+void ScrollBar::onFront(u32 localPlayerId, u32 /* r5 */) {
     auto *parentInputManager = getPage()->inputManager()->downcast<MultiControlInputManager>();
     assert(parentInputManager);
     if (!parentInputManager->isPointer(localPlayerId)) {
@@ -211,8 +211,8 @@ void ScrollBar::onFront([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32
     playSound(Sound::SoundId::SE_UI_CTRL_ON, localPlayerId);
 }
 
-void ScrollBar::onRight([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {}
+void ScrollBar::onRight(u32 /* localPlayerId */, u32 /* r5 */) {}
 
-void ScrollBar::onLeft([[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 r5) {}
+void ScrollBar::onLeft(u32 /* localPlayerId */, u32 /* r5 */) {}
 
 } // namespace UI

--- a/payload/game/ui/ServicePackToolsPage.cc
+++ b/payload/game/ui/ServicePackToolsPage.cc
@@ -49,20 +49,20 @@ void ServicePackToolsPage::onActivate() {
     m_replacement = PageId::None;
 }
 
-void ServicePackToolsPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void ServicePackToolsPage::onBack(u32 /* localPlayerId */) {
     m_replacement = PageId::ServicePackTop;
     startReplace(Anim::Prev, 0.0f);
 }
 
-void ServicePackToolsPage::onStorageBenchmarkButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackToolsPage::onStorageBenchmarkButtonFront(PushButton * button,
+        u32 /* localPlayerId */) {
     m_replacement = PageId::StorageBenchmark;
     f32 delay = button->getDelay();
     startReplace(Anim::Next, delay);
 }
 
-void ServicePackToolsPage::onThumbnailsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackToolsPage::onThumbnailsButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     if (SP::ThumbnailManager::Start()) {
         auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
         menuScenario.players[0].vehicleId = 1;
@@ -95,8 +95,8 @@ void ServicePackToolsPage::onThumbnailsButtonFront([[maybe_unused]] PushButton *
     }
 }
 
-void ServicePackToolsPage::onServerModeButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackToolsPage::onServerModeButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     Section *section = SectionManager::Instance()->currentSection();
     auto *messagePage = section->page<PageId::MenuMessage>();
     messagePage->reset();
@@ -109,14 +109,14 @@ void ServicePackToolsPage::onServerModeButtonFront([[maybe_unused]] PushButton *
     startReplace(Anim::None, delay);
 }
 
-void ServicePackToolsPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackToolsPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_replacement = PageId::ServicePackTop;
     f32 delay = button->getDelay();
     startReplace(Anim::Prev, delay);
 }
 
-void ServicePackToolsPage::onThumbnailsNoCoursePop([[maybe_unused]] MessagePage *messagePage) {
+void ServicePackToolsPage::onThumbnailsNoCoursePop(MessagePage *messagePage) {
     reinterpret_cast<MenuMessagePage *>(messagePage)->m_replacement = PageId::ServicePackTools;
 }
 

--- a/payload/game/ui/ServicePackTopPage.cc
+++ b/payload/game/ui/ServicePackTopPage.cc
@@ -50,33 +50,33 @@ void ServicePackTopPage::onActivate() {
     m_replacement = PageId::None;
 }
 
-void ServicePackTopPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void ServicePackTopPage::onBack(u32 /* localPlayerId */) {
     changeSection(SectionId::TitleFromOptions, Anim::Prev, 0.0f);
 }
 
-void ServicePackTopPage::onToolsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackTopPage::onToolsButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_replacement = PageId::ServicePackTools;
     f32 delay = button->getDelay();
     startReplace(Anim::Next, delay);
 }
 
-void ServicePackTopPage::onUpdateButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackTopPage::onUpdateButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_replacement = PageId::Update;
     f32 delay = button->getDelay();
     startReplace(Anim::Next, delay);
 }
 
-void ServicePackTopPage::onChannelButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackTopPage::onChannelButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_replacement = PageId::Channel;
     f32 delay = button->getDelay();
     startReplace(Anim::Next, delay);
 }
 
-void ServicePackTopPage::onAboutButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackTopPage::onAboutButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     Section *section = SectionManager::Instance()->currentSection();
     auto *confirmPage = section->page<PageId::Confirm>();
     confirmPage->reset();
@@ -93,14 +93,14 @@ void ServicePackTopPage::onAboutButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void ServicePackTopPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void ServicePackTopPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     f32 delay = button->getDelay();
     changeSection(SectionId::TitleFromOptions, Anim::Prev, delay);
 }
 
-void ServicePackTopPage::onAboutPop([[maybe_unused]] ConfirmPage *confirmPage,
-        [[maybe_unused]] f32 delay) {
+void ServicePackTopPage::onAboutPop(ConfirmPage *confirmPage,
+        f32 /* delay */) {
     confirmPage->m_replacement = PageId::ServicePackTop;
 }
 

--- a/payload/game/ui/SettingsPage.cc
+++ b/payload/game/ui/SettingsPage.cc
@@ -82,7 +82,7 @@ BlackBackControl *SettingsPage::blackBack() {
     return nullptr;
 }
 
-void SettingsPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void SettingsPage::onBack(u32 /* localPlayerId */) {
     if (m_handler) {
         m_handler->handle(this, nullptr);
     }
@@ -90,18 +90,18 @@ void SettingsPage::onBack([[maybe_unused]] u32 localPlayerId) {
     startReplace(Anim::Prev, 0.0f);
 }
 
-void SettingsPage::onCategoryControlFront([[maybe_unused]] UpDownControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void SettingsPage::onCategoryControlFront(UpDownControl */* control */,
+        u32 localPlayerId) {
     m_settingControls[0].select(localPlayerId);
 }
 
-void SettingsPage::onCategoryControlSelect([[maybe_unused]] UpDownControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void SettingsPage::onCategoryControlSelect(UpDownControl */* control */,
+        u32 /* localPlayerId */) {
     instructionText()->setMessageAll(0);
 }
 
-void SettingsPage::onCategoryValueChange([[maybe_unused]] TextUpDownValueControl::TextControl *text,
-        [[maybe_unused]] u32 index) {
+void SettingsPage::onCategoryValueChange(TextUpDownValueControl::TextControl *text,
+        u32 index) {
     auto categoryInfo = getCategoryInfo(index);
 
     if (categoryInfo.categorySheetCount >= 2) {
@@ -155,8 +155,8 @@ void SettingsPage::onCategoryValueChange([[maybe_unused]] TextUpDownValueControl
     }
 }
 
-void SettingsPage::onSettingControlChange([[maybe_unused]] UpDownControl *control,
-        [[maybe_unused]] u32 localPlayerId, [[maybe_unused]] u32 index) {
+void SettingsPage::onSettingControlChange(UpDownControl *control,
+        u32 /* localPlayerId */, u32 index) {
     auto *text = m_settingValues[control->m_id & 0xffff].shownText();
     const SP::ClientSettings::Entry &entry = SP::ClientSettings::entries[control->m_id >> 16];
     if (entry.valueNames) {
@@ -175,8 +175,8 @@ void SettingsPage::onSettingControlChange([[maybe_unused]] UpDownControl *contro
     }
 }
 
-void SettingsPage::onSettingControlFront([[maybe_unused]] UpDownControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void SettingsPage::onSettingControlFront(UpDownControl *control,
+        u32 localPlayerId) {
     u32 index = control->m_id & 0xffff;
     if (index + 1 == std::size(m_settingControls) || !m_settingControls[index + 1].getVisible()) {
         m_categoryControl.select(localPlayerId);
@@ -185,8 +185,8 @@ void SettingsPage::onSettingControlFront([[maybe_unused]] UpDownControl *control
     }
 }
 
-void SettingsPage::onSettingControlSelect([[maybe_unused]] UpDownControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void SettingsPage::onSettingControlSelect(UpDownControl *control,
+        u32 /* localPlayerId */) {
     u32 chosen = control->chosen();
     const SP::ClientSettings::Entry &entry = SP::ClientSettings::entries[control->m_id >> 16];
     if (entry.valueNames) {
@@ -199,8 +199,8 @@ void SettingsPage::onSettingControlSelect([[maybe_unused]] UpDownControl *contro
     }
 }
 
-void SettingsPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SettingsPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     if (m_handler) {
         m_handler->handle(this, button);
     }

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -100,12 +100,12 @@ void SingleTopPage::onActivate() {
     }
 }
 
-void SingleTopPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onBack(u32 /* localPlayerId */) {
     changeSection(SectionId::TitleFromMenu, Anim::Prev, 0.0f);
 }
 
-void SingleTopPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onSettingsButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *settingsPage = section->page<PageId::MenuSettings>();
     settingsPage->configure(nullptr, PageId::SingleTop);
@@ -114,13 +114,13 @@ void SingleTopPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void SingleTopPage::onSettingsButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onSettingsButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(10077);
 }
 
-void SingleTopPage::onTAButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onTAButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
     menuScenario.engineClass = System::RaceConfig::EngineClass::CC150;
     menuScenario.gameMode = System::RaceConfig::GameMode::TimeAttack;
@@ -140,8 +140,8 @@ void SingleTopPage::onTAButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void SingleTopPage::onTAButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onTAButtonSelect(PushButton *button,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(3051);
 
     Section *section = SectionManager::Instance()->currentSection();
@@ -149,8 +149,8 @@ void SingleTopPage::onTAButtonSelect([[maybe_unused]] PushButton *button,
     modelPage->modelControl().setModel(0);
 }
 
-void SingleTopPage::onVSButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onVSButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *saveManager = System::SaveManager::Instance();
     auto *context = SectionManager::Instance()->globalContext();
     context->m_matchCount = saveManager->getSetting<SP::ClientSettings::Setting::VSRaceCount>();
@@ -180,8 +180,8 @@ void SingleTopPage::onVSButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void SingleTopPage::onVSButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onVSButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(3052);
 
     Section *section = SectionManager::Instance()->currentSection();
@@ -189,8 +189,8 @@ void SingleTopPage::onVSButtonSelect([[maybe_unused]] PushButton *button,
     modelPage->modelControl().setModel(2);
 }
 
-void SingleTopPage::onBTButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onBTButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *saveManager = System::SaveManager::Instance();
     auto *context = SectionManager::Instance()->globalContext();
     context->m_matchCount = saveManager->getSetting<SP::ClientSettings::Setting::BTRaceCount>();
@@ -219,8 +219,8 @@ void SingleTopPage::onBTButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void SingleTopPage::onBTButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onBTButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(3054);
 
     Section *section = SectionManager::Instance()->currentSection();
@@ -229,8 +229,8 @@ void SingleTopPage::onBTButtonSelect([[maybe_unused]] PushButton *button,
 }
 
 #if ENABLE_MR
-void SingleTopPage::onMRButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onMRButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
     menuScenario.gameMode = System::RaceConfig::GameMode::Mission;
     menuScenario.cameraMode = 0;
@@ -249,8 +249,8 @@ void SingleTopPage::onMRButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void SingleTopPage::onMRButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onMRButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(10161);
 
     Section *section = SectionManager::Instance()->currentSection();
@@ -259,14 +259,14 @@ void SingleTopPage::onMRButtonSelect([[maybe_unused]] PushButton *button,
 }
 #endif
 
-void SingleTopPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     f32 delay = button->getDelay();
     changeSection(SectionId::TitleFromMenu, Anim::Prev, delay);
 }
 
-void SingleTopPage::onBackButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void SingleTopPage::onBackButtonSelect(PushButton *button,
+        u32 /* localPlayerId */) {
     m_instructionText.setMessage(0);
 }
 

--- a/payload/game/ui/TeamConfirmPage.cc
+++ b/payload/game/ui/TeamConfirmPage.cc
@@ -93,7 +93,7 @@ TeamConfirmPage *TeamConfirmPage::Get(PageId id) {
     return section->page<PageId::TeamConfirm>();
 }
 
-void TeamConfirmPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void TeamConfirmPage::onBack(u32 /* localPlayerId */) {
     auto sectionId = SectionManager::Instance()->currentSection()->id();
     if (sectionId == SectionId::Multi) {
         m_replacement = PageId::MultiTeamSelect;
@@ -103,8 +103,8 @@ void TeamConfirmPage::onBack([[maybe_unused]] u32 localPlayerId) {
     startReplace(Anim::Prev, 0.0f);
 }
 
-void TeamConfirmPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TeamConfirmPage::onSettingsButtonFront(PushButton * button,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *menuSettingsPage = section->page<PageId::MenuSettings>();
     menuSettingsPage->configure(nullptr, PageId::TeamConfirm);
@@ -113,8 +113,8 @@ void TeamConfirmPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void TeamConfirmPage::onOkButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TeamConfirmPage::onOkButtonFront(PushButton * button,
+        u32 /* localPlayerId */) {
     auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
     if (menuScenario.gameMode == System::RaceConfig::GameMode::OfflineVS) {
         System::RaceConfig::Instance()->applyEngineClass();
@@ -131,8 +131,8 @@ void TeamConfirmPage::onOkButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void TeamConfirmPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TeamConfirmPage::onBackButtonFront(PushButton * button,
+        u32 /* localPlayerId */) {
     auto sectionId = SectionManager::Instance()->currentSection()->id();
     if (sectionId == SectionId::Multi) {
         m_replacement = PageId::MultiTeamSelect;

--- a/payload/game/ui/TimeAttackGhostListPage.cc
+++ b/payload/game/ui/TimeAttackGhostListPage.cc
@@ -191,15 +191,15 @@ void TimeAttackGhostListPage::chooseGhost(u32 buttonIndex) {
     refreshLaunchButtons();
 }
 
-void TimeAttackGhostListPage::onBack([[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onBack(u32 /* localPlayerId */) {
     m_cc.reset();
 
     m_replacement = PageId::CourseSelect;
     startReplace(Anim::Prev, 0.0f);
 }
 
-void TimeAttackGhostListPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onSettingsButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *menuSettingsPage = section->page<PageId::MenuSettings>();
     menuSettingsPage->configure(nullptr, PageId::TimeAttackGhostList);
@@ -208,22 +208,22 @@ void TimeAttackGhostListPage::onSettingsButtonFront([[maybe_unused]] PushButton 
     startReplace(Anim::Next, delay);
 }
 
-void TimeAttackGhostListPage::onSettingsButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onSettingsButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_sheetSelect.setPointerOnly(true);
     m_watchButton.setPointerOnly(true);
 
     m_lastSelected = -1;
 }
 
-void TimeAttackGhostListPage::onSettingsButtonDeselect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onSettingsButtonDeselect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_sheetSelect.setPointerOnly(false);
     m_watchButton.setPointerOnly(false);
 }
 
-void TimeAttackGhostListPage::onSheetSelectRight([[maybe_unused]] SheetSelectControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onSheetSelectRight(SheetSelectControl */* control */,
+        u32 /* localPlayerId */) {
     if (!canSwapGhostSelects()) {
         return;
     }
@@ -241,8 +241,8 @@ void TimeAttackGhostListPage::onSheetSelectRight([[maybe_unused]] SheetSelectCon
     swapGhostSelects();
 }
 
-void TimeAttackGhostListPage::onSheetSelectLeft([[maybe_unused]] SheetSelectControl *control,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onSheetSelectLeft(SheetSelectControl */* control */,
+        u32 /* localPlayerId */) {
     if (!canSwapGhostSelects()) {
         return;
     }
@@ -260,51 +260,51 @@ void TimeAttackGhostListPage::onSheetSelectLeft([[maybe_unused]] SheetSelectCont
     swapGhostSelects();
 }
 
-void TimeAttackGhostListPage::onAloneButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onAloneButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_isReplay = false;
 
     push(PageId::RaceConfirm, Anim::Next);
 }
 
-void TimeAttackGhostListPage::onAloneButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onAloneButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_lastSelected = -1;
 }
 
-void TimeAttackGhostListPage::onRaceButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onRaceButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_isReplay = false;
 
     push(PageId::RaceConfirm, Anim::Next);
 }
 
-void TimeAttackGhostListPage::onRaceButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onRaceButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_lastSelected = -1;
 }
 
-void TimeAttackGhostListPage::onWatchButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onWatchButtonFront(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_isReplay = true;
 
     push(PageId::RaceConfirm, Anim::Next);
 }
 
-void TimeAttackGhostListPage::onWatchButtonSelect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onWatchButtonSelect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_settingsButton.setPointerOnly(true);
 
     m_lastSelected = -1;
 }
 
-void TimeAttackGhostListPage::onWatchButtonDeselect([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onWatchButtonDeselect(PushButton * /* button */,
+        u32 /* localPlayerId */) {
     m_settingsButton.setPointerOnly(false);
 }
 
-void TimeAttackGhostListPage::onBackButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void TimeAttackGhostListPage::onBackButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     m_cc.reset();
 
     m_replacement = PageId::CourseSelect;

--- a/payload/game/ui/UpdatePage.cc
+++ b/payload/game/ui/UpdatePage.cc
@@ -304,11 +304,11 @@ void UpdatePage::transition(State state) {
     m_state = state;
 }
 
-void *UpdatePage::Check(void *UNUSED(arg)) {
+void *UpdatePage::Check(void */* arg */) {
     return reinterpret_cast<void *>(SP::Update::Check());
 }
 
-void *UpdatePage::Update(void *UNUSED(arg)) {
+void *UpdatePage::Update(void */* arg */) {
     return reinterpret_cast<void *>(SP::Update::Update());
 }
 

--- a/payload/game/ui/ctrl/CtrlRaceNameBalloon.cc
+++ b/payload/game/ui/ctrl/CtrlRaceNameBalloon.cc
@@ -186,7 +186,7 @@ void BalloonManager::init(u8 localPlayerId) {
     }
 }
 
-void BalloonManager::addNameControl(CtrlRaceNameBalloon *UNUSED(nameControl)) {
+void BalloonManager::addNameControl(CtrlRaceNameBalloon */* nameControl */) {
     m_nameCount++;
 }
 

--- a/payload/game/ui/page/DriftSelectPage.cc
+++ b/payload/game/ui/page/DriftSelectPage.cc
@@ -13,8 +13,8 @@ void DriftSelectPage::onActivate() {
     selectDefault(m_buttons[sectionManager->globalContext()->m_driftModes[0] != 1]);
 }
 
-void DriftSelectPage::onButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void DriftSelectPage::onButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *sectionManager = SectionManager::Instance();
     auto *section = sectionManager->currentSection();
     auto sectionId = section->id();

--- a/payload/game/ui/page/MultiDriftSelectPage.cc
+++ b/payload/game/ui/page/MultiDriftSelectPage.cc
@@ -4,8 +4,8 @@
 
 namespace UI {
 
-void MultiDriftSelectPage::onButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void MultiDriftSelectPage::onButtonFront(PushButton *button,
+        u32 localPlayerId) {
     // Back button processing
     s32 buttonIdx = button->m_index;
     if (buttonIdx == -100 && localPlayerId == 0) {

--- a/payload/game/ui/page/RaceMenuPage.cc
+++ b/payload/game/ui/page/RaceMenuPage.cc
@@ -15,8 +15,8 @@ extern "C" {
 
 namespace UI {
 
-void RaceMenuPage::onButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void RaceMenuPage::onButtonFront(PushButton *button,
+        u32 localPlayerId) {
     auto &raceScenario = System::RaceConfig::Instance()->raceScenario();
     auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
 
@@ -59,8 +59,8 @@ void RaceMenuPage::onButtonFront([[maybe_unused]] PushButton *button,
     }
 }
 
-void RaceMenuPage::onNextButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void RaceMenuPage::onNextButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     System::RaceConfig::Instance()->endRace();
 
     playSound(Sound::SoundId::SE_RC_PAUSE_EXIT_GAME, -1);
@@ -107,8 +107,8 @@ void RaceMenuPage::onNextButtonFront([[maybe_unused]] PushButton *button,
     Sound::BackgroundMusicManager::Instance()->prepare(Section::GetSoundId(sectionId), true);
 }
 
-void RaceMenuPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void RaceMenuPage::onSettingsButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     auto *section = SectionManager::Instance()->currentSection();
     auto *menuSettingsPage = section->page<PageId::MenuSettings>();
     menuSettingsPage->configure(nullptr, id());
@@ -117,8 +117,8 @@ void RaceMenuPage::onSettingsButtonFront([[maybe_unused]] PushButton *button,
     startReplace(Anim::Next, delay);
 }
 
-void RaceMenuPage::onChangeGhostDataButtonFront([[maybe_unused]] PushButton *button,
-        [[maybe_unused]] u32 localPlayerId) {
+void RaceMenuPage::onChangeGhostDataButtonFront(PushButton *button,
+        u32 /* localPlayerId */) {
     playSound(Sound::SoundId::SE_RC_PAUSE_EXIT_GAME, -1);
 
     auto &menuScenario = System::RaceConfig::Instance()->menuScenario();

--- a/payload/game/ui/page/TimeAttackSplitsPage.c
+++ b/payload/game/ui/page/TimeAttackSplitsPage.c
@@ -6,7 +6,7 @@
 
 s32 TimeAttackSplitsPage_getReplacement(TimeAttackSplitsPage *this);
 
-s32 my_TimeAttackSplitsPage_getReplacement(TimeAttackSplitsPage *UNUSED(this)) {
+s32 my_TimeAttackSplitsPage_getReplacement(TimeAttackSplitsPage */* this */) {
     return PAGE_ID_AFTER_TA_MENU;
 }
 PATCH_B(TimeAttackSplitsPage_getReplacement, my_TimeAttackSplitsPage_getReplacement);

--- a/payload/nw4r/db/dbException.c
+++ b/payload/nw4r/db/dbException.c
@@ -4,7 +4,7 @@
 extern void Exception_Printf_(const char *, ...);
 extern void Exception_PrintCtx();
 
-static void line1(const char *UNUSED(str), u32 frame) {
+static void line1(const char */* str */, u32 frame) {
     Host_PrintMkwSpInfo(Exception_Printf_);
     Exception_Printf_("******** EXCEPTION OCCURRED! ********\nFrameMemory:%XH\n", frame);
 }

--- a/payload/nw4r/snd/DVDSoundArchive.cc
+++ b/payload/nw4r/snd/DVDSoundArchive.cc
@@ -15,11 +15,11 @@ void DVDSoundArchive::dt(s32 type) {
     SoundArchive::dt(type);
 }
 
-const void *DVDSoundArchive::getFileAddress(u32 UNUSED(fileId)) {
+const void *DVDSoundArchive::getFileAddress(u32 /* fileId */) {
     return nullptr;
 }
 
-const void *DVDSoundArchive::getWaveDataFileAddress(u32 UNUSED(fileId)) {
+const void *DVDSoundArchive::getWaveDataFileAddress(u32 /* fileId */) {
     return nullptr;
 }
 
@@ -45,7 +45,7 @@ ut::FileStream *DVDSoundArchive::openStream(void *buffer, s32 size, u32 start, u
 }
 
 ut::FileStream *DVDSoundArchive::openExtStream(void *buffer, s32 size, const char *extFilePath,
-        u32 UNUSED(start), u32 UNUSED(length)) {
+        u32 /* start */, u32 /* length */) {
     if (size < static_cast<s32>(sizeof(FileStream))) {
         return nullptr;
     }

--- a/payload/revolution/dvd.c
+++ b/payload/revolution/dvd.c
@@ -73,7 +73,7 @@ BOOL DVDReadDir(DVDDir *dir, DVDDirEntry *dirent) {
     return true;
 }
 
-BOOL DVDCloseDir(DVDDir *UNUSED(dir)) {
+BOOL DVDCloseDir(DVDDir */* dir */) {
     return true;
 }
 

--- a/payload/revolution/os/OSError.c
+++ b/payload/revolution/os/OSError.c
@@ -41,7 +41,7 @@ static inline BinaryType ClassifyCaller(void *sp) {
     return ClassifyPointer(addr);
 }
 
-__attribute__((noreturn)) REPLACE void OSPanic(const char *UNUSED(filename), int UNUSED(lineNumber),
+__attribute__((noreturn)) REPLACE void OSPanic(const char */* filename */, int /* lineNumber */,
         const char *message, ...) {
     char messageFormat[256];
     NWC24iStrLCpy(messageFormat, message, sizeof(messageFormat));

--- a/payload/sp/3d/Kcl.cc
+++ b/payload/sp/3d/Kcl.cc
@@ -296,7 +296,7 @@ void KclVis::prepare() {
         TPLGetGXTexObjFromPalette(TRUSS_TPL, &TRUSS_OBJ, 0);
     }
 }
-void KclVis::render(const float mtx[3][4], [[maybe_unused]] bool overlay) {
+void KclVis::render(const float mtx[3][4], bool /* overlay */) {
     GXLoadPosMtxImm(mtx, 0);
     float ident[4][4];
     PSMTXIdentity(ident);

--- a/payload/sp/cs/RoomClient.cc
+++ b/payload/sp/cs/RoomClient.cc
@@ -15,7 +15,7 @@ extern "C" {
 
 namespace SP {
 
-bool RoomClient::isPlayerLocal([[maybe_unused]] u32 playerId) const {
+bool RoomClient::isPlayerLocal(u32 playerId) const {
     for (size_t i = 0; i < m_localPlayerCount; i++) {
         if (m_localPlayerIds[i] == playerId) {
             return true;
@@ -25,16 +25,15 @@ bool RoomClient::isPlayerLocal([[maybe_unused]] u32 playerId) const {
     return false;
 }
 
-bool RoomClient::isPlayerRemote([[maybe_unused]] u32 playerId) const {
+bool RoomClient::isPlayerRemote(u32 playerId) const {
     return playerId < m_playerCount && !isPlayerLocal(playerId);
 }
 
-bool RoomClient::canSelectTeam([[maybe_unused]] u32 playerId) const {
+bool RoomClient::canSelectTeam(u32 playerId) const {
     return isPlayerLocal(playerId);
 }
 
-bool RoomClient::canSelectTeam([[maybe_unused]] u32 localPlayerId,
-        [[maybe_unused]] u32 playerId) const {
+bool RoomClient::canSelectTeam(u32 localPlayerId, u32 playerId) const {
     assert(localPlayerId < m_localPlayerCount);
     return m_localPlayerIds[localPlayerId] == playerId;
 }
@@ -484,7 +483,7 @@ bool RoomClient::onReceiveComment(Handler &handler, u32 playerId, u32 messageId)
     return true;
 }
 
-bool RoomClient::onRoomStart(Handler &handler, u32 gamemode) {
+bool RoomClient::onRoomStart(Handler &/* handler */, u32 gamemode) {
     if (gamemode >= 3) {
         return false;
     }

--- a/payload/sp/cs/RoomManager.hh
+++ b/payload/sp/cs/RoomManager.hh
@@ -21,20 +21,20 @@ public:
         virtual void onTeamSelect() {}
         virtual void onSelect() {}
 
-        virtual void onPlayerJoin([[maybe_unused]] const System::RawMii *mii,
-                [[maybe_unused]] u32 location, [[maybe_unused]] u16 latitude,
-                [[maybe_unused]] u16 longitude, [[maybe_unused]] u32 regionLineColor) {}
-        virtual void onPlayerLeave([[maybe_unused]] u32 playerId) {}
-        virtual void onReceiveComment([[maybe_unused]] u32 playerId,
-                [[maybe_unused]] u32 commentId) {}
+        virtual void onPlayerJoin(const System::RawMii */* mii */,
+                u32 /* location */, u16 /* latitude */,
+                u16 /* longitude */, u32 /* regionLineColor */) {}
+        virtual void onPlayerLeave(u32 /* playerId */) {}
+        virtual void onReceiveComment(u32 /* playerId */,
+                u32 /* commentId */) {}
         virtual void onSettingsChange(
-                [[maybe_unused]] const std::array<u32, RoomSettings::count> &settings) {}
-        virtual void onReceiveTeamSelect([[maybe_unused]] u32 playerId,
-                [[maybe_unused]] u32 teamId) {}
-        virtual void onReceivePulse([[maybe_unused]] u32 playerId) {}
-        virtual void onReceiveInfo([[maybe_unused]] u32 playerId, [[maybe_unused]] s32 course,
-                [[maybe_unused]] u32 selectedPlayer, [[maybe_unused]] u32 character,
-                [[maybe_unused]] u32 vehicle) {}
+                const std::array<u32, RoomSettings::count> &/* settings */) {}
+        virtual void onReceiveTeamSelect(u32 /* playerId */,
+                u32 /* teamId */) {}
+        virtual void onReceivePulse(u32 /* playerId */) {}
+        virtual void onReceiveInfo(u32 /* playerId */, s32 /* course */,
+                u32 /* selectedPlayer */, u32 /* character */,
+                u32 /* vehicle */) {}
         virtual void onError(u32 errorCode);
     };
 

--- a/payload/sp/net/Net.cc
+++ b/payload/sp/net/Net.cc
@@ -25,7 +25,7 @@ void *Alloc(s32 size) {
     return nullptr;
 }
 
-static void *Alloc(u32 UNUSED(id), s32 size) {
+static void *Alloc(u32 /* id */, s32 size) {
     return Alloc(size);
 }
 
@@ -40,11 +40,11 @@ void Free(void *ptr, s32 size) {
     assert(!"Bad alloc");
 }
 
-static void Free(u32 UNUSED(id), void *ptr, s32 size) {
+static void Free(u32 /* id */, void *ptr, s32 size) {
     return Free(ptr, size);
 }
 
-static void *Handle(void *UNUSED(arg)) {
+static void *Handle(void */* arg */) {
     res = SOStartup();
     while (true) {
         if (res != 0) {

--- a/payload/sp/storage/DVDStorage.cc
+++ b/payload/sp/storage/DVDStorage.cc
@@ -54,7 +54,7 @@ std::optional<FileHandle> DVDStorage::open(const wchar_t *path, const char *mode
     return file;
 }
 
-bool DVDStorage::createDir(const wchar_t *UNUSED(path), bool UNUSED(allowNop)) {
+bool DVDStorage::createDir(const wchar_t */* path */, bool /* allowNop */) {
     return false;
 }
 
@@ -131,11 +131,11 @@ std::optional<NodeInfo> DVDStorage::stat(const wchar_t *path) {
     return {};
 }
 
-bool DVDStorage::rename(const wchar_t *UNUSED(srcPath), const wchar_t *UNUSED(dstPath)) {
+bool DVDStorage::rename(const wchar_t */* srcPath */, const wchar_t */* dstPath */) {
     return false;
 }
 
-bool DVDStorage::remove(const wchar_t *UNUSED(path), bool UNUSED(allowNop)) {
+bool DVDStorage::remove(const wchar_t */* path */, bool /* allowNop */) {
     return false;
 }
 
@@ -179,7 +179,7 @@ bool DVDStorage::File::read(void *dst, u32 size, u32 offset) {
     return DVDRead(this, dst, size, offset);
 }
 
-bool DVDStorage::File::write(const void *UNUSED(src), u32 UNUSED(size), u32 UNUSED(offset)) {
+bool DVDStorage::File::write(const void */* src */, u32 /* size */, u32 /* offset */) {
     return false;
 }
 

--- a/payload/sp/storage/DecompLoader.cc
+++ b/payload/sp/storage/DecompLoader.cc
@@ -78,7 +78,7 @@ static void Read(StartInfo info) {
     updateExchange.right(0);
 }
 
-static void *Handle(void *UNUSED(arg)) {
+static void *Handle(void */* arg */) {
     while (true) {
         auto info = startExchange.right({});
         Read(info);

--- a/payload/sp/storage/LogFile.cc
+++ b/payload/sp/storage/LogFile.cc
@@ -27,7 +27,7 @@ static u16 offset = 0;
 static u8 stack[8192];
 static OSThread thread;
 
-static void *Run(void *UNUSED(arg)) {
+static void *Run(void */* arg */) {
     Storage::CreateDir(LOG_FILE_DIRECTORY, true);
 
     OSCalendarTime time;

--- a/payload/sp/storage/NANDArchiveStorage.cc
+++ b/payload/sp/storage/NANDArchiveStorage.cc
@@ -96,7 +96,7 @@ std::optional<FileHandle> NANDArchiveStorage::open(const wchar_t *path, const ch
     return file;
 }
 
-bool NANDArchiveStorage::createDir(const wchar_t *UNUSED(path), bool UNUSED(allowNop)) {
+bool NANDArchiveStorage::createDir(const wchar_t */* path */, bool /* allowNop */) {
     return false;
 }
 
@@ -173,11 +173,11 @@ std::optional<NodeInfo> NANDArchiveStorage::stat(const wchar_t *path) {
     return {};
 }
 
-bool NANDArchiveStorage::rename(const wchar_t *UNUSED(srcPath), const wchar_t *UNUSED(dstPath)) {
+bool NANDArchiveStorage::rename(const wchar_t */* srcPath */, const wchar_t */* dstPath */) {
     return false;
 }
 
-bool NANDArchiveStorage::remove(const wchar_t *UNUSED(path), bool UNUSED(allowNop)) {
+bool NANDArchiveStorage::remove(const wchar_t */* path */, bool /* allowNop */) {
     return false;
 }
 
@@ -250,7 +250,7 @@ bool NANDArchiveStorage::File::read(void *dst, u32 size, u32 offset) {
     return true;
 }
 
-bool NANDArchiveStorage::File::write(const void *UNUSED(src), u32 UNUSED(size), u32 UNUSED(offset)) {
+bool NANDArchiveStorage::File::write(const void */* src */, u32 /* size */, u32 /* offset */) {
     return false;
 }
 

--- a/payload/sp/storage/NetStorage.cc
+++ b/payload/sp/storage/NetStorage.cc
@@ -63,7 +63,7 @@ std::optional<FileHandle> NetStorage::open(const wchar_t *path, const char *mode
     return readOpen(file);
 }
 
-bool NetStorage::createDir(const wchar_t *UNUSED(path), bool UNUSED(allowNop)) {
+bool NetStorage::createDir(const wchar_t */* path */, bool /* allowNop */) {
     return false;
 }
 
@@ -119,11 +119,11 @@ std::optional<NodeInfo> NetStorage::stat(const wchar_t *path) {
     return readNodeInfo();
 }
 
-bool NetStorage::rename(const wchar_t *UNUSED(srcPath), const wchar_t *UNUSED(dstPath)) {
+bool NetStorage::rename(const wchar_t */* srcPath */, const wchar_t */* dstPath */) {
     return false;
 }
 
-bool NetStorage::remove(const wchar_t *UNUSED(path), bool UNUSED(allowNop)) {
+bool NetStorage::remove(const wchar_t */* path */, bool /* allowNop */) {
     return false;
 }
 

--- a/payload/sp/storage/Usb.c
+++ b/payload/sp/storage/Usb.c
@@ -253,7 +253,7 @@ static void Usb_updateDevices(void) {
     }
 }
 
-static void *Usb_discoverDevices(void *UNUSED(arg)) {
+static void *Usb_discoverDevices(void */* arg */) {
     while (true) {
         s32 result = IOS_Ioctl(fd, IOCTL_GET_DEVICE_CHANGE, NULL, 0, deviceEntries,
                 MAX_DEVICE_COUNT * sizeof(DeviceEntry));

--- a/payload/sp/storage/UsbStorage.c
+++ b/payload/sp/storage/UsbStorage.c
@@ -277,7 +277,7 @@ static bool UsbStorage_onDeviceAdd(const UsbDeviceInfo *info) {
     return true;
 }
 
-__attribute__((noreturn)) static void UsbStorage_onDeviceRemove(u32 UNUSED(id)) {
+__attribute__((noreturn)) static void UsbStorage_onDeviceRemove(u32 /* id */) {
     panic("Device was removed!");
 }
 
@@ -330,7 +330,7 @@ static bool UsbStorage_write(u32 firstSector, u32 sectorCount, const void *buffe
     return false;
 }
 
-static bool UsbStorage_erase(u32 UNUSED(firstSector), u32 UNUSED(sectorCount)) {
+static bool UsbStorage_erase(u32 /* firstSector */, u32 /* sectorCount */) {
     // This is not supported under Bulk Only Transport
     return true;
 }

--- a/vendor/ff/diskio.c
+++ b/vendor/ff/diskio.c
@@ -18,7 +18,7 @@
 /*-----------------------------------------------------------------------*/
 
 DSTATUS disk_status (
-    BYTE UNUSED(pdrv)   /* Physical drive nmuber to identify the drive */
+    BYTE /* pdrv: Physical drive nmuber to identify the drive */
 )
 {
     return 0;
@@ -31,7 +31,7 @@ DSTATUS disk_status (
 /*-----------------------------------------------------------------------*/
 
 DSTATUS disk_initialize (
-    BYTE UNUSED(pdrv)   /* Physical drive nmuber to identify the drive */
+    BYTE /* pdrv: Physical drive nmuber to identify the drive */
 )
 {
     return 0;
@@ -44,7 +44,7 @@ DSTATUS disk_initialize (
 /*-----------------------------------------------------------------------*/
 
 DRESULT disk_read (
-    BYTE UNUSED(pdrv),  /* Physical drive nmuber to identify the drive */
+    BYTE /* pdrv */,    /* Physical drive nmuber to identify the drive */
     BYTE *buff,         /* Data buffer to store read data */
     LBA_t sector,       /* Start sector in LBA */
     UINT count          /* Number of sectors to read */
@@ -62,7 +62,7 @@ DRESULT disk_read (
 #if FF_FS_READONLY == 0
 
 DRESULT disk_write (
-    BYTE UNUSED(pdrv),  /* Physical drive nmuber to identify the drive */
+    BYTE /* pdrv */,    /* Physical drive nmuber to identify the drive */
     const BYTE *buff,   /* Data to be written */
     LBA_t sector,       /* Start sector in LBA */
     UINT count          /* Number of sectors to write */
@@ -79,7 +79,7 @@ DRESULT disk_write (
 /*-----------------------------------------------------------------------*/
 
 DRESULT disk_ioctl (
-    BYTE UNUSED(pdrv),  /* Physical drive nmuber (0..) */
+    BYTE /* pdrv */,    /* Physical drive nmuber (0..) */
     BYTE cmd,           /* Control code */
     void *buff          /* Buffer to send/receive control data */
 )


### PR DESCRIPTION
This PR removes usage of `maybe_unused` and the `unused` macro and replaces with `/* arg */`. This avoids the ambiguity of maybe_unused and helps codebase uniformity