### PR TITLE
Fix certain pages requiring entire UI recompile

### DIFF
--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -5,6 +5,7 @@
 #include "game/ui/ModelPage.hh"
 #include "game/ui/SectionManager.hh"
 #include "game/ui/SettingsPage.hh"
+#include "game/ui/page/BattleModeSelectPage.hh"
 #include "game/ui/page/MenuPage.hh"
 
 namespace UI {

--- a/payload/game/ui/OnlineConnectionManagerPage.cc
+++ b/payload/game/ui/OnlineConnectionManagerPage.cc
@@ -2,8 +2,9 @@
 
 #include "game/system/SaveManager.hh"
 #include "game/system/RaceConfig.hh"
-#include "game/ui/SectionManager.hh"
 #include "game/ui/GlobalContext.hh"
+#include "game/ui/OnlineModeSelectPage.hh"
+#include "game/ui/SectionManager.hh"
 
 #include <protobuf/Matchmaking.pb.h>
 #include <sp/cs/RoomClient.hh>

--- a/payload/game/ui/OnlineModeSelectPage.cc
+++ b/payload/game/ui/OnlineModeSelectPage.cc
@@ -1,6 +1,7 @@
 #include "OnlineModeSelectPage.hh"
 
 #include "game/ui/SectionManager.hh"
+#include "game/ui/OnlineConnectionManagerPage.hh"
 
 namespace UI {
 

--- a/payload/game/ui/OnlineTopPage.cc
+++ b/payload/game/ui/OnlineTopPage.cc
@@ -1,5 +1,6 @@
 #include "OnlineTopPage.hh"
 
+#include "game/ui/OnlineConnectionManagerPage.hh"
 #include "game/ui/SectionManager.hh"
 #include "game/ui/SettingsPage.hh"
 #include "game/ui/MessagePage.hh"

--- a/payload/game/ui/RandomMatchingPage.cc
+++ b/payload/game/ui/RandomMatchingPage.cc
@@ -1,10 +1,11 @@
 #include "RandomMatchingPage.hh"
 
-#include "payload/game/system/RaceConfig.hh"
-#include "payload/game/ui/SectionManager.hh"
-#include "payload/game/ui/FriendRoomBackPage.hh"
+#include "game/system/RaceConfig.hh"
+#include "game/ui/SectionManager.hh"
+#include "game/ui/FriendRoomBackPage.hh"
+#include "game/ui/OnlineConnectionManagerPage.hh"
 
-#include <payload/sp/cs/RoomClient.hh>
+#include <sp/cs/RoomClient.hh>
 
 namespace UI {
 

--- a/payload/game/ui/RandomMatchingPage.hh
+++ b/payload/game/ui/RandomMatchingPage.hh
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "payload/game/ui/Page.hh"
-#include "payload/game/ui/ctrl/CtrlMenuPageTitleText.hh"
+#include "game/ui/Page.hh"
+#include "game/ui/ctrl/CtrlMenuPageTitleText.hh"
 
-#include <payload/sp/cs/RoomManager.hh>
+#include <sp/cs/RoomManager.hh>
 
 namespace UI {
 

--- a/payload/game/ui/Section.cc
+++ b/payload/game/ui/Section.cc
@@ -14,6 +14,8 @@
 #include "game/ui/ModelRenderPage.hh"
 #include "game/ui/MultiTeamSelectPage.hh"
 #include "game/ui/MultiTopPage.hh"
+#include "game/ui/OnlineConnectionManagerPage.hh"
+#include "game/ui/OnlineModeSelectPage.hh"
 #include "game/ui/OnlineTeamSelectPage.hh"
 #include "game/ui/OnlineTopPage.hh"
 #include "game/ui/RandomMatchingPage.hh"

--- a/payload/game/ui/Section.hh
+++ b/payload/game/ui/Section.hh
@@ -2,14 +2,12 @@
 
 #include "game/ui/Page.hh"
 #include "game/ui/SectionId.hh"
-#include "game/ui/page/BattleModeSelectPage.hh"
-#include "game/ui/OnlineConnectionManagerPage.hh"
-#include "game/ui/OnlineModeSelectPage.hh"
 
 #include <nw4r/lyt/lyt_drawInfo.hh>
 
 namespace UI {
 
+class BattleModeSelectPage;
 class ConfirmPage;
 class CourseSelectPage;
 class DriftSelectPage;
@@ -27,6 +25,8 @@ class MessagePagePopup;
 class MissionInstructionPage;
 class ModelPage;
 class ModelRenderPage;
+class OnlineConnectionManagerPage;
+class OnlineModeSelectPage;
 class OnlineTeamSelectPage;
 class OptionExplanationPage;
 class OptionSelectPage;

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -5,6 +5,7 @@
 #include "game/ui/ModelPage.hh"
 #include "game/ui/SectionManager.hh"
 #include "game/ui/SettingsPage.hh"
+#include "game/ui/page/BattleModeSelectPage.hh"
 #include "game/ui/page/MenuPage.hh"
 
 namespace UI {

--- a/payload/game/util/Registry.cc
+++ b/payload/game/util/Registry.cc
@@ -4,8 +4,8 @@ extern "C" {
 #include "Registry.h"
 }
 
-#include <payload/game/system/SaveManager.hh>
-#include <payload/sp/cs/RoomClient.hh>
+#include <game/system/SaveManager.hh>
+#include <sp/cs/RoomClient.hh>
 
 namespace Registry {
 


### PR DESCRIPTION
In my infinite wisdom, as I added pages, I added includes directly to `Section.hh`, instead of using a forward declaration as I didn't understand that at the time. This PR reduces the amount of steps ninja reports from `160` when modifying `BattleModeSelectPage.hh` to `60`...