### PR TITLE
Make debug builds optional

### DIFF
--- a/.github/workflows/build_sp.yml
+++ b/.github/workflows/build_sp.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install protobuf
         run: pip install protobuf
       - name: Configure ninja
-        run: ./configure.py --ci
+        run: ./configure.py --ci --default-targets test,debug
       - name: Compile
         run: ninja
       - name: Upload result

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The codebase uses both C and asm, C should be preferred for full function replac
 
 The codebase is automatically formatted using `clang-format` (15), this will be checked by CI and must be run before merge.
 
+If you need a unoptimised build with debugging information, use `ninja debug` to build once, or use
+`configure.py --default-targets` and then a comma seperated list of `test`, `debug`, or `release` to
+automatically build the requested binaries with every `ninja` invoke.
+
 ## Resources
 
 - [Ghidra project](https://drive.google.com/drive/folders/1I1VRfeut3NtPeddePutfAaZhduVdKhhc?usp=sharing) (by far the most complete resource)

--- a/configure.py
+++ b/configure.py
@@ -24,6 +24,7 @@ if platform.python_implementation() == "PyPy":
 
 parser = ArgumentParser()
 parser.add_argument('--gdb_compatible', action='store_true')
+parser.add_argument('--default-targets', default='test')
 parser.add_argument("--ci", action="store_true")
 args = parser.parse_args()
 
@@ -1488,10 +1489,7 @@ n.build(
 )
 n.newline()
 
-n.default([
-    'debug',
-    'test',
-])
+n.default(args.default_targets.split(','))
 n.newline()
 
 n.variable('configure', 'configure.py')


### PR DESCRIPTION
This PR adds a `--default-targets` argument to the `configure.py` script, which defaults to only build the `test` target. This speeds up compile time by 2x due to having to only compile the `test` target, and avoiding the `debug` target which currently is too large to launch on console.