### PR TITLE
Set section flags for the first section in Start.S

### DIFF
--- a/loader/Start.S
+++ b/loader/Start.S
@@ -1,6 +1,6 @@
 #include <Common.S>
 
-.section first
+.section first,"ax",@progbits
 .global start
 start:
     // Initialize the stack pointer


### PR DESCRIPTION
Allows lld to link the loader, as it errors for pc relative relocs in non-allocatable sections. Other flags are included for completeness.