### PR TITLE
Cleanup common files

### DIFF
--- a/common/IOS.cc
+++ b/common/IOS.cc
@@ -15,6 +15,16 @@ extern "C" volatile u32 armmsg;
 
 extern "C" volatile u32 irqmask;
 
+template <typename T>
+uintptr_t VirtualToPhysical(T *ptr) {
+    return reinterpret_cast<uintptr_t>(ptr) & 0x7fffffff;
+}
+
+template <typename T>
+T *PhysicalToVirtual(uintptr_t addr) {
+    return reinterpret_cast<T *>(addr | 0x80000000);
+}
+
 enum {
     X1 = 1 << 0,
     Y2 = 1 << 1,

--- a/fuzz/tests.cpp
+++ b/fuzz/tests.cpp
@@ -27,8 +27,7 @@ template <typename TFunctor>
 static auto MakeDefer(TFunctor &&F) {
     return Defer<TFunctor>(std::move(F));
 }
-#define CONCAT_IMPL(x, y) x##y
-#define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
+
 #define SP_DEFER(f) const auto MACRO_CONCAT(__tmp, __COUNTER__) = MakeDefer([&]() { f; })
 
 static void NetStorageClient_Test() {
@@ -103,7 +102,7 @@ static void NetStorageClient_Test() {
     std::vector<u8> decoded(decodedSize);
     Yaz_decode(encoded.data(), decoded.data(), encodedSize, decodedSize);
 
-    // Expected: U¬8-
+    // Expected: Uï¿½8-
     SP_LOG("BUF: %c%c%c%c", (char)decoded[0], (char)decoded[1], (char)decoded[2], (char)decoded[3]);
 
     {

--- a/include/Common.S
+++ b/include/Common.S
@@ -164,24 +164,3 @@
 
 #define PATCH_BL_END(dst, offset) \
     PATCH_BRANCH_END(dst, offset, 0x1)
-
-#define SETTING_RACE 0
-#define kSetting_DriftMode SETTING_RACE + 0
-#define kSetting_HudLabels SETTING_RACE + 1
-#define kSetting_169_Fov SETTING_RACE + 2
-#define kSetting_MapIcons SETTING_RACE + 3
-#define kSetting_PageTransitions SETTING_RACE + 4
-#define kSetting_RaceInputDisplay SETTING_RACE + 5
-
-#define SETTING_TA 6
-#define kSetting_TaRuleClass SETTING_TA + 0
-#define kSetting_TaRuleGhostSorting SETTING_TA + 1
-#define kSetting_TaRuleGhostTagVisibility SETTING_TA + 2
-#define kSetting_TaRuleGhostTagContent SETTING_TA + 3
-#define kSetting_TaRuleSolidGhosts SETTING_TA + 4
-#define kSetting_TaRuleGhostSound SETTING_TA + 5
-
-#define SETTING_LICENSE 12
-#define kSetting_MiiAvatar SETTING_LICENSE + 0 
-#define kSetting_MiiClient SETTING_LICENSE + 1
-#define kSetting_LoadingScreenColor SETTING_LICENSE + 2

--- a/include/Common.h
+++ b/include/Common.h
@@ -7,10 +7,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
-#define PLATFORM_EMULATOR
-#endif
-
 #define SP_DEBUG_STACK_RANDOMIZE (1 << 0)
 #define SP_DEBUG_IOS_OPENS (1 << 1)
 #define SP_DEBUG_LEVEL 0
@@ -23,12 +19,6 @@ enum {
 };
 
 #define static_assert_32bit(s) static_assert(kPlatformCurrent != kPlatform32 || (s))
-
-#ifdef PLATFORM_EMULATOR
-#define PLATFORM_LE
-#else
-#define PLATFORM_BE
-#endif
 
 #ifdef __cplusplus
 #define restrict __restrict
@@ -66,9 +56,6 @@ typedef double f64;
         _a > _b ? _a : _b; \
     })
 
-#define CONTAINER_OF(ptr, type, member) \
-    ((type *)((char *)(1 ? (ptr) : &((type *)0)->member) - offsetof(type, member)))
-
 //
 // WARNING: BUILD_BUG_ON_ZERO / MUST_BE_ARRAY returns 4 on Windows.
 //
@@ -84,12 +71,6 @@ typedef double f64;
 
 #define CONCAT_IMPL(x, y) x##y
 #define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
-
-#ifdef _MSC_VER
-#define PRAGMA_SECTION(s)
-#else
-#define PRAGMA_SECTION(s) __attribute__((section(s)))
-#endif
 
 #define PRAGMA(s) _Pragma(s)
 
@@ -130,17 +111,6 @@ extern VersionInfo versionInfo;
         RVL_OS_NEEDS_IMPORT; \
         OSReport("[" __FILE_NAME__ ":" SP_TOSTRING2(__LINE__) "] " m "\n", ##__VA_ARGS__); \
     } while (0)
-
-static size_t sp_wcslen(const wchar_t *w) {
-    size_t result = 0;
-    while (*w++) {
-        ++result;
-    }
-    return result;
-}
-
-#define VIRTUAL_TO_PHYSICAL(ptr) ((uintptr_t)(ptr)&0x7fffffff)
-#define PHYSICAL_TO_VIRTUAL(addr) ((void *)((addr) | 0x80000000))
 
 #define ROUND_UP(n, a) (((uintptr_t)(n) + (a)-1) & ~((a)-1))
 #define ROUND_DOWN(n, a) ((uintptr_t)(n) & ~(a - 1))

--- a/include/Common.hh
+++ b/include/Common.hh
@@ -18,16 +18,6 @@ T AlignUp(T val, size_t alignment) {
     return AlignDown<T>(val + alignment - 1, alignment);
 }
 
-template <typename T>
-uintptr_t VirtualToPhysical(T *ptr) {
-    return reinterpret_cast<uintptr_t>(ptr) & 0x7fffffff;
-}
-
-template <typename T>
-T *PhysicalToVirtual(uintptr_t addr) {
-    return reinterpret_cast<T *>(addr | 0x80000000);
-}
-
 static inline std::strong_ordering operator<=>(const VersionInfo &lhs, const VersionInfo &rhs) {
     if (auto cmp = lhs.major <=> rhs.major; cmp != 0) {
         return cmp;

--- a/payload/sp/Bytes.h
+++ b/payload/sp/Bytes.h
@@ -34,7 +34,7 @@ static inline u16 swap16(u16 v) {
 }
 #endif
 
-#ifdef PLATFORM_LE
+#ifdef PLATFORM_EMULATOR
 #include <string.h>
 
 // Respects strong aliasing, will never double evaluate

--- a/payload/sp/Commands.h
+++ b/payload/sp/Commands.h
@@ -2,6 +2,12 @@
 
 #include <Common.h>
 
+#ifdef _MSC_VER
+#define PRAGMA_SECTION(s)
+#else
+#define PRAGMA_SECTION(s) __attribute__((section(s)))
+#endif
+
 // Matches "/command", "/command arg", but not "/command2"
 bool StringStartsWithCommand(const char *line, const char *cmd);
 

--- a/payload/sp/Host.h
+++ b/payload/sp/Host.h
@@ -5,6 +5,10 @@
 // Keep this value in sync with the value in the file 'mkw-sp/protobuf/UpdateRequestMessage.options'
 #define HOST_PLATFORM_BUFFER_SIZE (31 + 1)
 
+#if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
+#define PLATFORM_EMULATOR
+#endif
+
 // clang-format off
 typedef enum {
     //! This is either a bug in the platform detection code,

--- a/payload/sp/security/PageTable.cc
+++ b/payload/sp/security/PageTable.cc
@@ -16,6 +16,7 @@ extern "C" void InitSRs();
 extern "C" void SetSDR1(u32 sdr1);
 
 namespace SP::PageTable {
+#define VIRTUAL_TO_PHYSICAL(ptr) ((uintptr_t)(ptr)&0x7fffffff)
 
 #define PAGE_TABLE_MEMORY_POWER_OF_2 16 // 64 Kibibytes
 static_assert(PAGE_TABLE_MEMORY_POWER_OF_2 > 15 && PAGE_TABLE_MEMORY_POWER_OF_2 < 26);


### PR DESCRIPTION
This removes unused functions/defines in `include`, and moves items which are only used once into the files they are only used.

Further cleanup has been tested, but doesn't improve compile time at all and causes a lot of churn.