### PR TITLE
Savestates: Include Item state in KartSaveState

### DIFF
--- a/payload/egg/core/eggSystem.c
+++ b/payload/egg/core/eggSystem.c
@@ -37,15 +37,15 @@ int sStickyItem = 0;
 int sStickyQty = 1;
 static void ClearItem(s32 myPlayerId) {
     if (s_itemDirector != NULL) {
-        s_itemDirector->mKartItems[myPlayerId].mCurrentItemKind = 20;
-        s_itemDirector->mKartItems[myPlayerId].mCurrentItemQty = 0;
+        s_itemDirector->m_kartItems[myPlayerId].mCurrentItemKind = 20;
+        s_itemDirector->m_kartItems[myPlayerId].mCurrentItemQty = 0;
     }
     sItemSticky = false;
 }
 static void TrySetItem(s32 myPlayerId, s32 item, s32 qty) {
     if (s_itemDirector != NULL) {
-        s_itemDirector->mKartItems[myPlayerId].mCurrentItemKind = item;
-        s_itemDirector->mKartItems[myPlayerId].mCurrentItemQty = qty;
+        s_itemDirector->m_kartItems[myPlayerId].mCurrentItemKind = item;
+        s_itemDirector->m_kartItems[myPlayerId].mCurrentItemQty = qty;
     }
 }
 

--- a/payload/game/item/ItemDirector.h
+++ b/payload/game/item/ItemDirector.h
@@ -4,20 +4,22 @@
 
 // Tentative name
 typedef struct {
-    char _[0x54 - 0x00];
-    char _54[0x88 - 0x54];
-    int _88;
-    int mCurrentItemKind;
-    int mCurrentItemQty;
-    // ...
+    u8 _00[0x88 - 0x00];
+    s32 _88;
+    s32 mCurrentItemKind;
+    s32 mCurrentItemQty;
+    u8 _94[0x248 - 0x94];
 } KartItem;
 
 // Tentative name
 typedef struct {
-    char _[0x14 - 0x00];
-    KartItem *mKartItems;
-    // ....
+    u8 _00[0x14 - 0x00];
+    KartItem *m_kartItems;
+    u8 _48[0x430 - 0x18];
 } ItemDirector;
+
+static_assert(sizeof(KartItem) == 0x248);
+static_assert(sizeof(ItemDirector) == 0x430);
 // extern ItemDirector *s_itemDirector;
 
 // Tentative name

--- a/payload/game/kart/KartSaveState.cc
+++ b/payload/game/kart/KartSaveState.cc
@@ -2,11 +2,12 @@
 
 namespace Kart {
 
-KartSaveState::KartSaveState(KartAccessor accessor, VehiclePhysics *physics) {
-    save(accessor, physics);
+KartSaveState::KartSaveState(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
+    save(accessor, physics, item);
 }
 
-void KartSaveState::save(KartAccessor accessor, VehiclePhysics *physics) {
+void KartSaveState::save(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
+    m_item = *item;
     m_physics = *physics;
     m_5c = *accessor.unk5c;
     m_sub = *accessor.sub;
@@ -27,7 +28,8 @@ void KartSaveState::save(KartAccessor accessor, VehiclePhysics *physics) {
     }
 }
 
-void KartSaveState::reload(KartAccessor accessor, VehiclePhysics *physics) {
+void KartSaveState::reload(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
+    *item = m_item;
     *physics = m_physics;
     *accessor.sub = m_sub;
     *accessor.unk5c = m_5c;

--- a/payload/game/kart/KartSaveState.hh
+++ b/payload/game/kart/KartSaveState.hh
@@ -5,7 +5,6 @@
 // most likely be added to SP::SaveStateManager.
 
 #pragma once
-
 #include "Kart5c.hh"
 #include "KartAction.hh"
 #include "KartBody.hh"
@@ -17,6 +16,10 @@
 #include "KartSus.hh"
 #include "KartTire.hh"
 #include "VehiclePhysics.hh"
+
+extern "C" {
+#include "game/item/ItemDirector.h"
+}
 
 namespace Kart {
 
@@ -32,10 +35,10 @@ struct KartTireFlat {
 
 class KartSaveState {
 public:
-    KartSaveState(KartAccessor accessor, VehiclePhysics *physics);
+    KartSaveState(KartAccessor accessor, VehiclePhysics *physics, KartItem *item);
 
-    void save(KartAccessor accessor, VehiclePhysics *physics);
-    void reload(KartAccessor accessor, VehiclePhysics *physics);
+    void save(KartAccessor accessor, VehiclePhysics *physics, KartItem *item);
+    void reload(KartAccessor accessor, VehiclePhysics *physics, KartItem *item);
 
 private:
     Kart5c m_5c;
@@ -48,6 +51,7 @@ private:
     KartTireFlat m_tire[4];
     KartCollide m_collide;
     VehiclePhysics m_physics;
+    KartItem m_item;
 };
 
 } // namespace Kart

--- a/payload/sp/SaveStateManager.cc
+++ b/payload/sp/SaveStateManager.cc
@@ -33,18 +33,20 @@ auto SaveStateManager::GetKartState() {
     auto kartObject = kartObjectManager->object(0);
     auto physics = kartObject->getVehiclePhysics();
 
-    return std::make_tuple(kartObject->m_accessor, physics);
+    auto item = s_itemDirector->m_kartItems;
+
+    return std::make_tuple(kartObject->m_accessor, physics, item);
 }
 
 void SaveStateManager::save() {
-    auto [accessor, physics] = GetKartState();
-    m_kartSaveState.emplace(accessor, physics);
+    auto [accessor, physics, item] = GetKartState();
+    m_kartSaveState.emplace(accessor, physics, item);
 }
 
 void SaveStateManager::reload() {
     if (m_kartSaveState.has_value()) {
-        auto [accessor, physics] = GetKartState();
-        (*m_kartSaveState).reload(accessor, physics);
+        auto [accessor, physics, item] = GetKartState();
+        (*m_kartSaveState).reload(accessor, physics, item);
     } else {
         SP_LOG("SaveStateManager: Reload requested without save!");
     }


### PR DESCRIPTION
This saves item state in KartSaveState, allowing for (as an example) practicing shortcuts that need shrooms without needing to use `/i`.