### PR TITLE
Re-add missing settings

### DIFF
--- a/assets/message/MenuSP_U.bmg.json5
+++ b/assets/message/MenuSP_U.bmg.json5
@@ -11,6 +11,9 @@
     "3400": {
         string: "Settings",
     },
+    "3420": {
+        string: "CPU Difficulty"
+    },
     "3475": {
         string: "Change settings for this licence.",
     },

--- a/payload/game/system/RaceConfig.cc
+++ b/payload/game/system/RaceConfig.cc
@@ -70,6 +70,21 @@ void RaceConfig::applyEngineClass() {
     }
 }
 
+void RaceConfig::applyItemFreq() {
+    SP::ClientSettings::ItemFrequency setting;
+
+    auto *saveManager = SaveManager::Instance();
+    if (m_menuScenario.gameMode == GameMode::OfflineVS) {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::VSItemFrequency>();
+    } else if (m_menuScenario.gameMode == GameMode::OfflineBT) {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::BTItemFrequency>();
+    } else {
+        panic("applyCPUMode called with invalid GameMode");
+    }
+
+    m_menuScenario.itemMode = static_cast<u32>(setting);
+}
+
 void RaceConfig::applyCPUMode() {
     SP::ClientSettings::CPUMode setting;
 

--- a/payload/game/system/RaceConfig.cc
+++ b/payload/game/system/RaceConfig.cc
@@ -33,6 +33,8 @@ void RaceConfig::applyEngineClass() {
 
     if (m_menuScenario.gameMode == GameMode::OfflineVS) {
         setting = saveManager->getSetting<SP::ClientSettings::Setting::VSClass>();
+    } else if (m_menuScenario.gameMode == GameMode::OfflineBT) {
+        setting = SP::ClientSettings::EngineClass::CC50;
     } else if (m_menuScenario.gameMode == GameMode::TimeAttack) {
         auto taSetting = saveManager->getSetting<SP::ClientSettings::Setting::TAClass>();
         if (taSetting == SP::ClientSettings::TAClass::CC150) {
@@ -66,6 +68,21 @@ void RaceConfig::applyEngineClass() {
     case SP::ClientSettings::EngineClass::Mirror:
         m_menuScenario.mirror = true;
     }
+}
+
+void RaceConfig::applyCPUMode() {
+    SP::ClientSettings::CPUMode setting;
+
+    auto *saveManager = SaveManager::Instance();
+    if (m_menuScenario.gameMode == GameMode::OfflineVS) {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::VSCPUMode>();
+    } else if (m_menuScenario.gameMode == GameMode::OfflineBT) {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::BTCPUMode>();
+    } else {
+        panic("applyCPUMode called with invalid GameMode");
+    }
+
+    m_menuScenario.cpuMode = static_cast<u32>(setting);
 }
 
 RaceConfig *RaceConfig::Instance() {

--- a/payload/game/system/RaceConfig.cc
+++ b/payload/game/system/RaceConfig.cc
@@ -97,7 +97,16 @@ void RaceConfig::applyCPUMode() {
         panic("applyCPUMode called with invalid GameMode");
     }
 
-    m_menuScenario.cpuMode = static_cast<u32>(setting);
+    if (setting != SP::ClientSettings::CPUMode::None) {
+        m_menuScenario.cpuMode = static_cast<u32>(setting);
+        return;
+    }
+
+    for (u32 i = 1; i < 12; i++) {
+        if (m_menuScenario.players[i].type == Player::Type::CPU) {
+            m_menuScenario.players[i].type = Player::Type::None;
+        }
+    }
 }
 
 RaceConfig *RaceConfig::Instance() {

--- a/payload/game/system/RaceConfig.hh
+++ b/payload/game/system/RaceConfig.hh
@@ -116,6 +116,7 @@ public:
     Scenario &awardsScenario();
     u8 (&ghostBuffers())[2][11][0x2800];
     void applyEngineClass();
+    void applyCPUMode();
     void endRace();
 
     void REPLACED(initRace)();

--- a/payload/game/system/RaceConfig.hh
+++ b/payload/game/system/RaceConfig.hh
@@ -116,6 +116,7 @@ public:
     Scenario &awardsScenario();
     u8 (&ghostBuffers())[2][11][0x2800];
     void applyEngineClass();
+    void applyItemFreq();
     void applyCPUMode();
     void endRace();
 

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -124,6 +124,7 @@ void MultiTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */) 
     menuScenario.cameraMode = 5;
 
     raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();
     for (u32 i = 0; i < localPlayerCount; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::Local;
@@ -171,6 +172,7 @@ void MultiTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */) 
 
     raceConfig->applyEngineClass();
     raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
     for (u32 i = 0; i < localPlayerCount; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::Local;
     }

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -123,6 +123,7 @@ void MultiTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */) 
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
+    raceConfig->applyCPUMode();
     raceConfig->applyEngineClass();
     for (u32 i = 0; i < localPlayerCount; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::Local;
@@ -169,6 +170,7 @@ void MultiTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */) 
     menuScenario.cameraMode = 5;
 
     raceConfig->applyEngineClass();
+    raceConfig->applyCPUMode();
     for (u32 i = 0; i < localPlayerCount; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::Local;
     }

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -123,15 +123,16 @@ void MultiTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */) 
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
-    raceConfig->applyCPUMode();
-    raceConfig->applyItemFreq();
-    raceConfig->applyEngineClass();
     for (u32 i = 0; i < localPlayerCount; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::Local;
     }
     for (u32 i = localPlayerCount; i < 12; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
+
+    raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
+    raceConfig->applyEngineClass();
 
     Section *section = SectionManager::Instance()->currentSection();
     auto *courseSelectPage = section->page<PageId::CourseSelect>();
@@ -170,15 +171,16 @@ void MultiTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */) 
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
-    raceConfig->applyEngineClass();
-    raceConfig->applyCPUMode();
-    raceConfig->applyItemFreq();
     for (u32 i = 0; i < localPlayerCount; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::Local;
     }
     for (u32 i = localPlayerCount; i < 12; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
+
+    raceConfig->applyEngineClass();
+    raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
 
     Section *section = SectionManager::Instance()->currentSection();
     auto *courseSelectPage = section->page<PageId::CourseSelect>();

--- a/payload/game/ui/PageId.hh
+++ b/payload/game/ui/PageId.hh
@@ -121,7 +121,7 @@ enum class PageId {
     // }
     TimeAttackTop = 0x70,
     TimeAttackGhostList = 0x71,
-    VSSelect = 0x72,
+    VSSelect = 0x72, // Unused
     VSSetting = 0x73,
     TeamConfirm = 0x74,
     BattleModeSelect = 0x75,

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -173,13 +173,14 @@ void SingleTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */)
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
-    raceConfig->applyCPUMode();
-    raceConfig->applyItemFreq();
-    raceConfig->applyEngineClass();
     menuScenario.players[0].type = System::RaceConfig::Player::Type::Local;
     for (u32 i = 1; i < 12; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
+
+    raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
+    raceConfig->applyEngineClass();
 
     Section *section = SectionManager::Instance()->currentSection();
     auto *courseSelectPage = section->page<PageId::CourseSelect>();
@@ -217,12 +218,13 @@ void SingleTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */)
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
-    raceConfig->applyCPUMode();
-    raceConfig->applyItemFreq();
     menuScenario.players[0].type = System::RaceConfig::Player::Type::Local;
     for (u32 i = 1; i < 12; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
+
+    raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
 
     Section *section = SectionManager::Instance()->currentSection();
     auto *courseSelectPage = section->page<PageId::CourseSelect>();

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -174,6 +174,7 @@ void SingleTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */)
     menuScenario.cameraMode = 5;
 
     raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();
     menuScenario.players[0].type = System::RaceConfig::Player::Type::Local;
     for (u32 i = 1; i < 12; i++) {
@@ -217,6 +218,7 @@ void SingleTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */)
     menuScenario.cameraMode = 5;
 
     raceConfig->applyCPUMode();
+    raceConfig->applyItemFreq();
     menuScenario.players[0].type = System::RaceConfig::Player::Type::Local;
     for (u32 i = 1; i < 12; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -173,6 +173,7 @@ void SingleTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */)
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
+    raceConfig->applyCPUMode();
     raceConfig->applyEngineClass();
     menuScenario.players[0].type = System::RaceConfig::Player::Type::Local;
     for (u32 i = 1; i < 12; i++) {
@@ -209,11 +210,13 @@ void SingleTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */)
 
     u32 maxTeamSize = SP::ClientSettings::GenerateMaxTeamSize(maxTeamSizeSetting);
 
-    auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
+    auto *raceConfig = System::RaceConfig::Instance();
+    auto &menuScenario = raceConfig->menuScenario();
     menuScenario.gameMode = System::RaceConfig::GameMode::OfflineBT;
     menuScenario.spMaxTeamSize = maxTeamSize;
     menuScenario.cameraMode = 5;
 
+    raceConfig->applyCPUMode();
     menuScenario.players[0].type = System::RaceConfig::Player::Type::Local;
     for (u32 i = 1; i < 12; i++) {
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -384,6 +384,16 @@ const Entry entries[] = {
         .valueMessageIds = (u32[]) { 10235, 10236, 10238, 10237, 10365, 10366 },
         .valueExplanationMessageIds = (u32[]) { 10239, 10240, 10242, 10241, 10361, 10362 },
     },
+    [static_cast<u32>(Setting::VSCPUMode)] = {
+        .category = Category::VS,
+        .name = magic_enum::enum_name(Setting::VSCPUMode),
+        .messageId = 3420,
+        .defaultValue = static_cast<u32>(CPUMode::Normal),
+        .valueCount = magic_enum::enum_count<CPUMode>(),
+        .valueNames = magic_enum::enum_names<CPUMode>().data(),
+        .valueMessageIds = (u32[]) { 3421, 3422, 3423 },
+        .valueExplanationMessageIds = (u32[]) { 3425, 3426, 3427 },
+    },
     [static_cast<u32>(Setting::VSVehicles)] = {
         .category = Category::VS,
         .name = magic_enum::enum_name(Setting::VSVehicles),
@@ -434,6 +444,16 @@ const Entry entries[] = {
         .valueNames = magic_enum::enum_names<CourseSelection>().data(),
         .valueMessageIds = (u32[]) { 3441, 10228, 3443 },
         .valueExplanationMessageIds = (u32[]) { 10425, 10426, 10427 },
+    },
+    [static_cast<u32>(Setting::BTCPUMode)] = {
+        .category = Category::BT,
+        .name = magic_enum::enum_name(Setting::BTCPUMode),
+        .messageId = 3420,
+        .defaultValue = static_cast<u32>(CPUMode::Normal),
+        .valueCount = magic_enum::enum_count<CPUMode>(),
+        .valueNames = magic_enum::enum_names<CPUMode>().data(),
+        .valueMessageIds = (u32[]) { 3421, 3422, 3423 },
+        .valueExplanationMessageIds = (u32[]) { 3425, 3426, 3427 },
     },
     [static_cast<u32>(Setting::BTVehicles)] = {
         .category = Category::BT,

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -391,8 +391,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(CPUMode::Normal),
         .valueCount = magic_enum::enum_count<CPUMode>(),
         .valueNames = magic_enum::enum_names<CPUMode>().data(),
-        .valueMessageIds = (u32[]) { 3421, 3422, 3423 },
-        .valueExplanationMessageIds = (u32[]) { 3425, 3426, 3427 },
+        .valueMessageIds = (u32[]) { 3421, 3422, 3423, 3424 },
+        .valueExplanationMessageIds = (u32[]) { 3425, 3426, 3427, 3428 },
     },
     [static_cast<u32>(Setting::VSVehicles)] = {
         .category = Category::VS,
@@ -462,8 +462,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(CPUMode::Normal),
         .valueCount = magic_enum::enum_count<CPUMode>(),
         .valueNames = magic_enum::enum_names<CPUMode>().data(),
-        .valueMessageIds = (u32[]) { 3421, 3422, 3423 },
-        .valueExplanationMessageIds = (u32[]) { 3425, 3426, 3427 },
+        .valueMessageIds = (u32[]) { 3421, 3422, 3423, 3424 },
+        .valueExplanationMessageIds = (u32[]) { 3425, 3426, 3427, 3428 },
     },
     [static_cast<u32>(Setting::BTVehicles)] = {
         .category = Category::BT,

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -404,6 +404,16 @@ const Entry entries[] = {
         .valueMessageIds = (u32[]) { 10244, 10245, 10246, 10247, 10248, 10249, 10250 },
         .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, 10254, 10255, 10256, 10257 },
     },
+    [static_cast<u32>(Setting::VSItemFrequency)] = {
+        .category = Category::VS,
+        .name = magic_enum::enum_name(Setting::VSItemFrequency),
+        .messageId = 3480,
+        .defaultValue = static_cast<u32>(ItemFrequency::Balanced),
+        .valueCount = magic_enum::enum_count<ItemFrequency>(),
+        .valueNames = magic_enum::enum_names<ItemFrequency>().data(),
+        .valueMessageIds = (u32[]) { 3481, 3482, 3483 },
+        .valueExplanationMessageIds = (u32[]) { 3485, 3486, 3487 },
+    },
     [static_cast<u32>(Setting::VSMegaClouds)] = {
         .category = Category::VS,
         .name = magic_enum::enum_name(Setting::VSMegaClouds),
@@ -464,6 +474,16 @@ const Entry entries[] = {
         .valueNames = magic_enum::enum_names<Vehicles>().data(),
         .valueMessageIds = (u32[]) { 10244, 10245, 10246, 10247, 10248, 10249, 10250 },
         .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, 10254, 10255, 10256, 10257 },
+    },
+    [static_cast<u32>(Setting::BTItemFrequency)] = {
+        .category = Category::BT,
+        .name = magic_enum::enum_name(Setting::BTItemFrequency),
+        .messageId = 3480,
+        .defaultValue = static_cast<u32>(ItemFrequency::Balanced),
+        .valueCount = magic_enum::enum_count<ItemFrequency>(),
+        .valueNames = magic_enum::enum_names<ItemFrequency>().data(),
+        .valueMessageIds = (u32[]) { 3481, 3482, 3483 },
+        .valueExplanationMessageIds = (u32[]) { 3485, 3486, 3487 },
     },
     [static_cast<u32>(Setting::RoomTeamSize)] = {
         .category = Category::Room,

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -114,6 +114,7 @@ enum class CPUMode : u32 {
     Easy = 0,
     Normal = 1,
     Hard = 2,
+    None = 3,
 };
 
 enum class CourseSelection {

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -52,6 +52,7 @@ enum class Setting {
     VSClass,
     VSCPUMode,
     VSVehicles,
+    VSItemFrequency,
     VSMegaClouds,
 
     // Battle
@@ -60,6 +61,7 @@ enum class Setting {
     BTCourseSelection,
     BTCPUMode,
     BTVehicles,
+    BTItemFrequency,
 
     // Room
     RoomTeamSize,
@@ -128,6 +130,13 @@ enum class Vehicles {
     OutsideDrift,
     Optimal,
     Random,
+};
+
+enum class ItemFrequency {
+    Balanced,
+    Aggressive,
+    Strategic,
+    None,
 };
 
 enum class TeamSize {
@@ -536,6 +545,11 @@ struct Helper<ClientSettings::Setting, ClientSettings::Setting::VSVehicles> {
 };
 
 template <>
+struct Helper<ClientSettings::Setting, ClientSettings::Setting::VSItemFrequency> {
+    using type = SP::ClientSettings::ItemFrequency;
+};
+
+template <>
 struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTTeamSize> {
     using type = SP::ClientSettings::TeamSize;
 };
@@ -558,6 +572,11 @@ struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTCPUMode> {
 template <>
 struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTVehicles> {
     using type = SP::ClientSettings::Vehicles;
+};
+
+template <>
+struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTItemFrequency> {
+    using type = SP::ClientSettings::ItemFrequency;
 };
 
 template <>

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -50,6 +50,7 @@ enum class Setting {
     VSRaceCount,
     VSCourseSelection,
     VSClass,
+    VSCPUMode,
     VSVehicles,
     VSMegaClouds,
 
@@ -57,6 +58,7 @@ enum class Setting {
     BTTeamSize,
     BTRaceCount,
     BTCourseSelection,
+    BTCPUMode,
     BTVehicles,
 
     // Room
@@ -104,6 +106,12 @@ enum class EngineClass {
     Mirror,
     CC50,
     CC100,
+};
+
+enum class CPUMode : u32 {
+    Easy = 0,
+    Normal = 1,
+    Hard = 2,
 };
 
 enum class CourseSelection {
@@ -518,6 +526,11 @@ struct Helper<ClientSettings::Setting, ClientSettings::Setting::VSClass> {
 };
 
 template <>
+struct Helper<ClientSettings::Setting, ClientSettings::Setting::VSCPUMode> {
+    using type = SP::ClientSettings::CPUMode;
+};
+
+template <>
 struct Helper<ClientSettings::Setting, ClientSettings::Setting::VSVehicles> {
     using type = SP::ClientSettings::Vehicles;
 };
@@ -535,6 +548,11 @@ struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTRaceCount> {
 template <>
 struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTCourseSelection> {
     using type = SP::ClientSettings::CourseSelection;
+};
+
+template <>
+struct Helper<ClientSettings::Setting, ClientSettings::Setting::BTCPUMode> {
+    using type = SP::ClientSettings::CPUMode;
 };
 
 template <>


### PR DESCRIPTION
This re-adds the settings from vanilla that were missing from the new settings menu, which closes #519.

I have no idea how to test these work, but I can't imagine how they would not.