### PR TITLE
Try fix CI for formatting

### DIFF
--- a/.github/workflows/build_sp.yml
+++ b/.github/workflows/build_sp.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install clang-format
-        run: sudo apt install clang-format-15
+        run: sudo apt-get update && sudo apt-get install clang-format-15
       - name: Format MKW-SP
         run: |
           dirs="common include loader payload protobuf stub"

--- a/payload/game/system/GhostFile.hh
+++ b/payload/game/system/GhostFile.hh
@@ -174,4 +174,4 @@ class GhostGroup {
 };
 static_assert(sizeof(GhostGroup) == 0x14);
 
-} // namespace System
+}


### PR DESCRIPTION
Swaps out `apt` for `apt-get` to prevent warnings about an unstable interface, and adds an `update` to try and fix issues finding `clang-format-15`