### PR TITLE
Remove some unnecessary header includes

### DIFF
--- a/common/DCache.cc
+++ b/common/DCache.cc
@@ -1,9 +1,7 @@
 #include "DCache.hh"
 
 #ifdef SP_PAYLOAD
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 #endif
 
 namespace DCache {

--- a/include/Common.hh
+++ b/include/Common.hh
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <compare>
-
 extern "C" {
 #include "Common.h"
 }
 
 #include <array>
-#include <type_traits>
-#include <utility>
+#include <compare>
 
 template <typename T>
 T AlignDown(T val, size_t alignment) {

--- a/payload/egg/core/eggDisplay.hh
+++ b/payload/egg/core/eggDisplay.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <Common.hh>
 
 namespace EGG {
 

--- a/payload/egg/core/eggHeap.hh
+++ b/payload/egg/core/eggHeap.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.hh>
 #include <nw4r/ut/ut_list.hh>
 
 namespace EGG {

--- a/payload/egg/core/eggScene.h
+++ b/payload/egg/core/eggScene.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.h>
 #include <egg/core/eggColorFader.h>
 #include <egg/core/eggHeap.h>
 

--- a/payload/egg/core/eggSceneManager.cc
+++ b/payload/egg/core/eggSceneManager.cc
@@ -1,9 +1,5 @@
 #include "eggSceneManager.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-#include <game/host_system/SystemManager.hh>
 #include <game/system/RaceConfig.hh>
 #include <game/system/ResourceManager.hh>
 #include <game/system/SaveManager.hh>

--- a/payload/egg/core/eggSceneManager.h
+++ b/payload/egg/core/eggSceneManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.h>
 #include <egg/core/eggColorFader.h>
 
 typedef struct EGG_SceneManager {

--- a/payload/egg/core/eggSystem.h
+++ b/payload/egg/core/eggSystem.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Common.h>
-#include <egg/core/eggScene.h>
 #include <egg/core/eggSceneManager.h>
 #include <revolution.h>
 

--- a/payload/egg/core/eggThread.hh
+++ b/payload/egg/core/eggThread.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution/os/OSThread.h>
-}
+#include <revolution.hh>
 
 namespace EGG {
 

--- a/payload/egg/util/eggException.cc
+++ b/payload/egg/util/eggException.cc
@@ -5,11 +5,8 @@
 #include <common/Clock.hh>
 #include <game/host_system/SystemManager.hh>
 extern "C" {
-#include <revolution/ax.h>
 #include <revolution/kpad.h>
-#include <revolution/os.h>
-#include <revolution/pad.h>
-#include <revolution/vi.h>
+#include <revolution/wpad.h>
 }
 
 #include <cstring>

--- a/payload/game/host_system/SystemManager.cc
+++ b/payload/game/host_system/SystemManager.cc
@@ -4,10 +4,6 @@
 #include "game/system/RaceManager.hh"
 #include "game/ui/Section.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace System {
 
 void SystemManager::init() {

--- a/payload/game/race/AwardsManager.cc
+++ b/payload/game/race/AwardsManager.cc
@@ -1,7 +1,6 @@
 #include "AwardsManager.hh"
 
 #include <algorithm>
-#include <array>
 #include <numeric>
 
 namespace Race {

--- a/payload/game/race/FieldDirector.hh
+++ b/payload/game/race/FieldDirector.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.h>
 #include <nw4r/g3d/g3d_resmdl_ac.hh>
 
 namespace Race {

--- a/payload/game/render/DrawList.hh
+++ b/payload/game/render/DrawList.hh
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <Common.h>
-#include <array>
+#include <Common.hh>
 
 namespace Render {
 

--- a/payload/game/render/DrawMdl.hh
+++ b/payload/game/render/DrawMdl.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.hh>
 #include <nw4r/g3d/g3d_resmdl_ac.hh>
 
 namespace Render {

--- a/payload/game/sound/SceneSoundManager.hh
+++ b/payload/game/sound/SceneSoundManager.hh
@@ -4,8 +4,6 @@
 
 #include <nw4r/snd/SoundHandle.hh>
 
-#include <Common.hh>
-
 namespace Sound {
 
 class SceneSoundManager {

--- a/payload/game/system/BugCheck.cc
+++ b/payload/game/system/BugCheck.cc
@@ -1,7 +1,6 @@
 extern "C" {
 #include "game/system/FatalScene.h"
 
-#include <revolution.h>
 #include <sp/StackTrace.h>
 #include <sp/WideUtil.h>
 }

--- a/payload/game/system/Console.c
+++ b/payload/game/system/Console.c
@@ -2,7 +2,6 @@
 #include <game/ui/Font.h>
 #include <game/ui/FontManager.h>
 #include <nw4r/lyt/lyt_layout.h>
-#include <revolution.h>
 #include <sp/FormattingCodes.h>
 #include <sp/ScopeLock.h>
 #include <sp/keyboard/Keyboard.h>

--- a/payload/game/system/Console.h
+++ b/payload/game/system/Console.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <stdarg.h>
-#include <stddef.h>
 
 void Console_init(void);
 void Console_draw(void);

--- a/payload/game/system/DvdArchive.cc
+++ b/payload/game/system/DvdArchive.cc
@@ -1,9 +1,5 @@
 #include "DvdArchive.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-
 #include <sp/ThumbnailManager.hh>
 #include <sp/cs/RoomManager.hh>
 #include <sp/settings/ClientSettings.hh>

--- a/payload/game/system/FatalScene.c
+++ b/payload/game/system/FatalScene.c
@@ -2,7 +2,6 @@
 #include <egg/core/eggColorFader.h>
 #include <egg/core/eggSystem.h>
 #include <nw4r/lyt/lyt_pane.h>
-#include <revolution.h>
 #include <sp/storage/DecompLoader.h>
 
 #include <stdarg.h>

--- a/payload/game/system/GameScene.cc
+++ b/payload/game/system/GameScene.cc
@@ -4,10 +4,6 @@
 
 #include <sp/settings/ClientSettings.hh>
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace System {
 
 void GameScene::setFramerate(bool is_30) {

--- a/payload/game/system/GhostFile.cc
+++ b/payload/game/system/GhostFile.cc
@@ -5,8 +5,8 @@ extern "C" {
 }
 
 #include <common/Bytes.hh>
+#include <revolution.hh>
 extern "C" {
-#include <revolution.h>
 #include <rfl.h>
 #include <sp/Yaz.h>
 }

--- a/payload/game/system/GhostWriter.cc
+++ b/payload/game/system/GhostWriter.cc
@@ -3,9 +3,7 @@
 #include "game/system/InputManager.hh"
 #include "game/system/RaceConfig.hh"
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace System {
 

--- a/payload/game/system/MultiDvdArchive.cc
+++ b/payload/game/system/MultiDvdArchive.cc
@@ -1,9 +1,7 @@
 #include "MultiDvdArchive.hh"
 
-extern "C" {
-#include <revolution.h>
+#include <revolution.hh>
 #include <stdio.h>
-}
 
 namespace System {
 

--- a/payload/game/system/NandHelper.hh
+++ b/payload/game/system/NandHelper.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <Common.hh>
 
 namespace System {
 

--- a/payload/game/system/ResourceManager.cc
+++ b/payload/game/system/ResourceManager.cc
@@ -5,10 +5,6 @@
 #include <sp/storage/DecompLoader.hh>
 #include <sp/storage/Storage.hh>
 
-extern "C" {
-#include <revolution.h>
-}
-
 #include <cstdio>
 
 namespace System {

--- a/payload/game/system/SceneCreatorDynamic.c
+++ b/payload/game/system/SceneCreatorDynamic.c
@@ -1,5 +1,4 @@
 #include "FatalScene.h"
-#include <Common.h>
 #include <revolution.h>
 
 EGGScene *SceneCreatorDynamic_createOther(void * /* this */, u32 sceneId) {

--- a/payload/game/system/SceneCreatorDynamic.c
+++ b/payload/game/system/SceneCreatorDynamic.c
@@ -1,5 +1,4 @@
 #include "FatalScene.h"
-#include <revolution.h>
 
 EGGScene *SceneCreatorDynamic_createOther(void * /* this */, u32 sceneId) {
     OSReport("SceneCreatorDynamic_createOther %u\n", sceneId);

--- a/payload/game/ui/AwardPage.cc
+++ b/payload/game/ui/AwardPage.cc
@@ -5,7 +5,6 @@
 #include "game/ui/SectionManager.hh"
 
 #include <algorithm>
-#include <array>
 #include <cstdio>
 #include <numeric>
 

--- a/payload/game/ui/ChannelPage.hh
+++ b/payload/game/ui/ChannelPage.hh
@@ -2,10 +2,6 @@
 
 #include "game/ui/Page.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace UI {
 
 class ChannelPage : public Page {

--- a/payload/game/ui/Font.h
+++ b/payload/game/ui/Font.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "../system/Mii.h"
-#include <revolution.h>
-
 #include <nw4r/lyt/lyt_pane.h>
 #include <nw4r/ut/ut_resFont.h>
 

--- a/payload/game/ui/FontManager.c
+++ b/payload/game/ui/FontManager.c
@@ -1,7 +1,5 @@
 #include "FontManager.h"
 
-#include <revolution.h>
-
 Font *sDebugFont;
 
 static void FontManager_initFont(FontManager *this, u32 index, const char *file) {

--- a/payload/game/ui/FriendRoomBackPage.cc
+++ b/payload/game/ui/FriendRoomBackPage.cc
@@ -8,10 +8,6 @@
 
 #include <numeric>
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace UI {
 
 FriendRoomBackPage::FriendRoomBackPage() = default;

--- a/payload/game/ui/GhostSelectButton.cc
+++ b/payload/game/ui/GhostSelectButton.cc
@@ -1,10 +1,8 @@
 #include "GhostSelectButton.hh"
 
-#include "game/ui/TimeAttackGhostListPage.hh"
-extern "C" {
-#include "game/util/Registry.h"
-}
 #include "game/system/SaveManager.hh"
+#include "game/ui/TimeAttackGhostListPage.hh"
+#include "game/util/Registry.hh"
 
 #include <stdio.h>
 
@@ -130,7 +128,7 @@ void GhostSelectButton::refresh(u32 listIndex) {
         setPicture("flag_light_02", countryPane);
     }
 
-    const char *characterPane = getCharacterPane(header->characterId);
+    const char *characterPane = Registry::GetCharacterPane(header->characterId);
     setPicture("chara_shadow", characterPane);
     setPicture("chara", characterPane);
     setPicture("active_chara", characterPane);

--- a/payload/game/ui/GhostSelectControl.hh
+++ b/payload/game/ui/GhostSelectControl.hh
@@ -2,7 +2,6 @@
 
 #include "game/ui/GhostSelectButton.hh"
 #include "game/ui/UIControl.hh"
-#include <array>
 
 namespace UI {
 

--- a/payload/game/ui/LicenseSelectPage.hh
+++ b/payload/game/ui/LicenseSelectPage.hh
@@ -4,8 +4,6 @@
 #include "game/ui/ctrl/CtrlMenuBackButton.hh"
 #include "game/ui/ctrl/CtrlMenuPageTitleText.hh"
 
-#include <array>
-
 namespace UI {
 
 class LicenseSelectPage : public Page {

--- a/payload/game/ui/Map2DRenderer.c
+++ b/payload/game/ui/Map2DRenderer.c
@@ -1,6 +1,3 @@
-#include <Common.h>
-#include <revolution/gx/GXEnum.h>
-
 #include <revolution.h>
 
 enum MinimapFormats {

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -7,8 +7,6 @@
 #include "game/ui/SectionManager.hh"
 #include "game/ui/SettingsPage.hh"
 #include "game/ui/page/BattleModeSelectPage.hh"
-#include "game/ui/page/MenuPage.hh"
-#include <sp/settings/ClientSettings.hh>
 
 extern "C" {
 #include <vendor/libhydrogen/hydrogen.h>

--- a/payload/game/ui/OnlineTeamSelectPage.hh
+++ b/payload/game/ui/OnlineTeamSelectPage.hh
@@ -6,8 +6,6 @@
 #include "game/ui/ctrl/CtrlMenuInstructionText.hh"
 #include "game/ui/ctrl/CtrlMenuPageTitleText.hh"
 
-#include <array>
-
 namespace UI {
 
 class OnlineTeamSelectPage : public Page {

--- a/payload/game/ui/RoulettePage.hh
+++ b/payload/game/ui/RoulettePage.hh
@@ -6,7 +6,6 @@
 
 #include <sp/cs/RoomManager.hh>
 
-#include <array>
 #include <bitset>
 
 namespace UI {

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -7,7 +7,6 @@
 #include "game/ui/SectionManager.hh"
 #include "game/ui/SettingsPage.hh"
 #include "game/ui/page/BattleModeSelectPage.hh"
-#include "game/ui/page/MenuPage.hh"
 
 #include <sp/settings/ClientSettings.hh>
 extern "C" {

--- a/payload/game/ui/StorageBenchmarkPage.hh
+++ b/payload/game/ui/StorageBenchmarkPage.hh
@@ -4,10 +4,6 @@
 
 #include <sp/storage/Storage.hh>
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace UI {
 
 class StorageBenchmarkPage : public Page {

--- a/payload/game/ui/TeamColors.hh
+++ b/payload/game/ui/TeamColors.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace UI::TeamColors {
 

--- a/payload/game/ui/TitlePage.cc
+++ b/payload/game/ui/TitlePage.cc
@@ -5,8 +5,8 @@
 
 extern "C" {
 #include <sp/Host.h>
-}
 #include <vendor/libhydrogen/hydrogen.h>
+}
 
 namespace UI {
 

--- a/payload/game/ui/UpdatePage.hh
+++ b/payload/game/ui/UpdatePage.hh
@@ -2,10 +2,6 @@
 
 #include "game/ui/MessagePage.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace UI {
 
 class UpdatePage : public Page {

--- a/payload/game/ui/ctrl/CtrlRaceSpeed.cc
+++ b/payload/game/ui/ctrl/CtrlRaceSpeed.cc
@@ -6,10 +6,6 @@
 #include "game/kart/VehiclePhysics.hh"
 #include "game/system/SaveManager.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-
 namespace UI {
 
 namespace GroupId {

--- a/payload/game/ui/page/ResultTeamTotalPage.hh
+++ b/payload/game/ui/page/ResultTeamTotalPage.hh
@@ -4,8 +4,6 @@
 #include "game/ui/ctrl/CtrlRaceResultTeamPoint.hh"
 #include "game/ui/page/ResultPage.hh"
 
-#include <array>
-
 namespace UI {
 
 class ResultTeamTotalPage : public ResultPage {

--- a/payload/game/util/Registry.h
+++ b/payload/game/util/Registry.h
@@ -1,5 +1,4 @@
 #pragma once
 
-const char *getCharacterPane(u32 characterId);
 u32 getVehicleWeightClass(u32 vehicleId);
 u32 getCharacterWeightClass(u32 characterId);

--- a/payload/nw4r/g3d/MSan.c
+++ b/payload/nw4r/g3d/MSan.c
@@ -1,9 +1,6 @@
-#include <Common.h>
 #include <revolution.h>
 
-#include <stdbool.h> /* bool */
-#include <stdint.h>  /* uint8_t */
-#include <string.h>  /* memcpy */
+#include <string.h> /* memcpy */
 
 #ifdef MDLSAN_DEBUG
 #define MSA_DEBUG_LOG SP_LOG
@@ -152,7 +149,7 @@ static const char *getMaterialName(uint8_t *pMat) {
  * - Indirect matrices (control skew) are omitted, leaving
  *   them undefined.
  */
-void sanitizeMaterial(uint8_t *pMat) {
+void sanitizeMaterial(u8 *pMat) {
     MSA_VERBOSE_LOG("Sanitizing material %p", pMat);
 
     /* If the user is confident the material does not flicker, respect that. */

--- a/payload/nw4r/g3d/MSan.h
+++ b/payload/nw4r/g3d/MSan.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <stdint.h> // uint8_t
+#include <Common.h>
 
-void sanitizeMaterial(uint8_t *pMat);
+void sanitizeMaterial(u8 *pMat);

--- a/payload/nw4r/g3d/g3d_resmat.c
+++ b/payload/nw4r/g3d/g3d_resmat.c
@@ -1,8 +1,6 @@
 #include "g3d_resmat.h"
 #include "MSan.h"
 
-#include <Common.h>
-
 uint8_t *HookMatInit(uint8_t **pMat) {
     sanitizeMaterial(*pMat);
 

--- a/payload/nw4r/g3d/g3d_resmdl_ac.hh
+++ b/payload/nw4r/g3d/g3d_resmdl_ac.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.hh>
 extern "C" {
 #include <revolution/gx.h>
 }

--- a/payload/nw4r/g3d/g3d_resmdl_ac.hh
+++ b/payload/nw4r/g3d/g3d_resmdl_ac.hh
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Common.hh>
+extern "C" {
 #include <revolution/gx.h>
+}
 
 /*
 Helpful asserts:

--- a/payload/nw4r/lyt/lyt_material.hh
+++ b/payload/nw4r/lyt/lyt_material.hh
@@ -2,10 +2,6 @@
 
 #include "nw4r/lyt/lyt_texMap.hh"
 
-extern "C" {
-#include <revolution.h>
-}
-
 #include <Common.hh>
 
 namespace nw4r::lyt {

--- a/payload/nw4r/lyt/lyt_texMap.hh
+++ b/payload/nw4r/lyt/lyt_texMap.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace nw4r::lyt {
 

--- a/payload/nw4r/snd/FileStream.hh
+++ b/payload/nw4r/snd/FileStream.hh
@@ -2,9 +2,6 @@
 
 #include "nw4r/ut/FileStream.hh"
 
-extern "C" {
-#include <revolution.h>
-}
 #include <sp/storage/Storage.hh>
 
 namespace nw4r::snd {

--- a/payload/platform/guard.c
+++ b/payload/platform/guard.c
@@ -1,6 +1,5 @@
 // Reference: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#once-ctor
 
-#include <Common.h>
 #include <revolution.h>
 
 typedef struct {

--- a/payload/revolution.hh
+++ b/payload/revolution.hh
@@ -1,0 +1,5 @@
+#pragma once
+
+extern "C" {
+#include "revolution.h"
+}

--- a/payload/revolution/exi.c
+++ b/payload/revolution/exi.c
@@ -1,7 +1,5 @@
 #include "exi.h"
 
-#include <Common.h>
-
 typedef struct {
     u8 _00[0x20 - 0x00];
     u32 _20;

--- a/payload/revolution/kpad.h
+++ b/payload/revolution/kpad.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Common.h>
-
 #include "revolution/wpad.h"
 
 enum {

--- a/payload/revolution/si.h
+++ b/payload/revolution/si.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.h>
 #include <sp/ScopeLock.h>
 
 typedef void (*SICallback)(s32, u32, void *);

--- a/payload/revolution/wpad.h
+++ b/payload/revolution/wpad.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Common.h>
+
 enum {
     WPAD_BUTTON_LEFT = 0x1,
     WPAD_BUTTON_RIGHT = 0x2,

--- a/payload/sp/3d/Checkpoints.cc
+++ b/payload/sp/3d/Checkpoints.cc
@@ -1,10 +1,8 @@
 #include "Checkpoints.hh"
-#include <Common.hh>
 
 #include <game/system/CourseMap.hh>
 extern "C" {
 #include <revolution.h>
-#include <revolution/gx.h>
 }
 
 #include <egg/math/eggMath.hh>

--- a/payload/sp/3d/Checkpoints.cc
+++ b/payload/sp/3d/Checkpoints.cc
@@ -1,9 +1,7 @@
 #include "Checkpoints.hh"
 
 #include <game/system/CourseMap.hh>
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <egg/math/eggMath.hh>
 #include <numbers>

--- a/payload/sp/3d/Kcl.cc
+++ b/payload/sp/3d/Kcl.cc
@@ -2,7 +2,6 @@
 
 extern "C" {
 #include <revolution.h>
-#include <revolution/gx.h>
 #include <revolution/tpl.h>
 }
 

--- a/payload/sp/3d/Kcl.cc
+++ b/payload/sp/3d/Kcl.cc
@@ -1,7 +1,7 @@
 #include "Kcl.hh"
 
+#include <revolution.hh>
 extern "C" {
-#include <revolution.h>
 #include <revolution/tpl.h>
 }
 

--- a/payload/sp/3d/Kcl.hh
+++ b/payload/sp/3d/Kcl.hh
@@ -3,10 +3,10 @@
 #define _HAS_CXX20
 
 #include "Common.hh"
-#include <array>
 #include <common/TVec3.hh>
-#include <memory>
 #include <sp/FixedString.hh>
+
+#include <memory>
 #include <span>
 #include <variant>
 

--- a/payload/sp/Channel.cc
+++ b/payload/sp/Channel.cc
@@ -8,7 +8,6 @@ extern "C" {
 #include <revolution.h>
 }
 
-#include <array>
 #include <cstdio>
 #include <cstring>
 #include <optional>

--- a/payload/sp/Channel.cc
+++ b/payload/sp/Channel.cc
@@ -4,9 +4,7 @@
 
 #include <common/ES.hh>
 #include <common/Paths.hh>
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <cstdio>
 #include <cstring>

--- a/payload/sp/Exchange.hh
+++ b/payload/sp/Exchange.hh
@@ -2,9 +2,7 @@
 
 #include "sp/ScopeLock.hh"
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <optional>
 

--- a/payload/sp/FixedString.hh
+++ b/payload/sp/FixedString.hh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Common.h>
+#include <Common.hh>
+
 #include <algorithm>
-#include <array>
 #include <string_view>
 
 extern "C" {

--- a/payload/sp/FormattingCodes.h
+++ b/payload/sp/FormattingCodes.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.h>
 #include <sp/StringRange.h>
 
 typedef enum {

--- a/payload/sp/Host.cc
+++ b/payload/sp/Host.cc
@@ -1,8 +1,6 @@
 extern "C" {
 #include "Host.h"
 
-#include <Common.h>
-
 #include <revolution/ios.h>
 #include <revolution/nwc24/NWC24Utils.h>
 #include <revolution/os.h>

--- a/payload/sp/IOSDolphin.cc
+++ b/payload/sp/IOSDolphin.cc
@@ -2,9 +2,7 @@
 #include <span>
 #include <vendor/magic_enum/magic_enum.hpp>
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace SP::IOSDolphin {
 

--- a/payload/sp/IOSDolphin.cc
+++ b/payload/sp/IOSDolphin.cc
@@ -4,7 +4,6 @@
 
 extern "C" {
 #include <revolution.h>
-#include <stdalign.h>
 }
 
 namespace SP::IOSDolphin {

--- a/payload/sp/IOSDolphin.hh
+++ b/payload/sp/IOSDolphin.hh
@@ -4,8 +4,6 @@ extern "C" {
 #include <revolution/ios.h>
 }
 #include "FixedString.hh"
-#include <Common.h>
-#include <array>
 #include <expected>
 #include <string_view>
 

--- a/payload/sp/Payload.cc
+++ b/payload/sp/Payload.cc
@@ -39,7 +39,6 @@ extern "C" {
 #include <game/host_system/SystemManager.hh>
 extern "C" {
 #include <libhydrogen/hydrogen.h>
-#include <revolution.h>
 }
 
 #include <cstring>

--- a/payload/sp/PerfOverlay.cc
+++ b/payload/sp/PerfOverlay.cc
@@ -4,9 +4,6 @@
 
 #include <egg/core/eggSystem.hh>
 #include <game/system/SaveManager.hh>
-extern "C" {
-#include <revolution.h>
-}
 
 #include <algorithm>
 #include <cstring>

--- a/payload/sp/PerfOverlay.hh
+++ b/payload/sp/PerfOverlay.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <optional>
 

--- a/payload/sp/Rel.cc
+++ b/payload/sp/Rel.cc
@@ -11,7 +11,6 @@ extern "C" {
 
 extern "C" {
 #include <game/system/Console.h>
-#include <revolution.h>
 }
 
 #include <cstring>

--- a/payload/sp/SaveStateManager.cc
+++ b/payload/sp/SaveStateManager.cc
@@ -2,9 +2,7 @@
 
 #include "game/kart/KartObjectManager.hh"
 
-extern "C" {
-#include "revolution.h"
-}
+#include <revolution.hh>
 #include <tuple>
 
 namespace SP {

--- a/payload/sp/ScopeLock.hh
+++ b/payload/sp/ScopeLock.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace SP {
 

--- a/payload/sp/Slab.c
+++ b/payload/sp/Slab.c
@@ -1,5 +1,4 @@
 #include "Slab.h"
-#include <revolution.h>
 
 static void *AllocSlab(u8 *slabs, int alloc_size, int num_slabs) {
     // TODO: Some bitmask optimization

--- a/payload/sp/StringRange.h
+++ b/payload/sp/StringRange.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Common.h>
 #include <sp/StringView.h>
 
 typedef struct {

--- a/payload/sp/ThumbnailManager.hh
+++ b/payload/sp/ThumbnailManager.hh
@@ -2,6 +2,8 @@
 
 #include "sp/storage/Storage.hh"
 
+#include <array>
+
 namespace SP {
 
 class ThumbnailManager {

--- a/payload/sp/ThumbnailManager.hh
+++ b/payload/sp/ThumbnailManager.hh
@@ -2,8 +2,6 @@
 
 #include "sp/storage/Storage.hh"
 
-#include <array>
-
 namespace SP {
 
 class ThumbnailManager {

--- a/payload/sp/Time.cc
+++ b/payload/sp/Time.cc
@@ -1,8 +1,6 @@
 #include "Time.hh"
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <optional>
 

--- a/payload/sp/Update.cc
+++ b/payload/sp/Update.cc
@@ -10,8 +10,8 @@ extern "C" {
 #include <common/Paths.hh>
 
 #include <protobuf/Update.pb.h>
+#include <revolution.hh>
 extern "C" {
-#include <revolution.h>
 #include <revolution/nwc24/NWC24Utils.h>
 }
 #include <vendor/nanopb/pb_decode.h>

--- a/payload/sp/Yaz.c
+++ b/payload/sp/Yaz.c
@@ -1,7 +1,5 @@
 #include "Yaz.h"
 
-#include <stdint.h>
-
 enum {
     YAZ0_MAGIC = 0x59617a30,
     YAZ1_MAGIC = 0x59617a31,

--- a/payload/sp/cs/RoomClient.hh
+++ b/payload/sp/cs/RoomClient.hh
@@ -6,8 +6,6 @@
 #include <game/system/Mii.hh>
 #include <protobuf/Room.pb.h>
 
-#include <array>
-
 namespace SP {
 
 // RoomClient is responsible for writing requests and reading events

--- a/payload/sp/cs/RoomManager.hh
+++ b/payload/sp/cs/RoomManager.hh
@@ -4,8 +4,6 @@
 
 #include <game/system/Mii.hh>
 
-#include <array>
-
 namespace SP {
 
 // RoomManager is inherited by RoomClient and RoomServer

--- a/payload/sp/keyboard/Keyboard.c
+++ b/payload/sp/keyboard/Keyboard.c
@@ -1,5 +1,3 @@
-#include <Common.h>
-
 #include <sp/TypingBuffer.h>
 
 #include "IOSKeyboard.h"

--- a/payload/sp/keyboard/Keyboard.c
+++ b/payload/sp/keyboard/Keyboard.c
@@ -1,5 +1,4 @@
 #include <Common.h>
-#include <revolution.h>
 
 #include <sp/TypingBuffer.h>
 

--- a/payload/sp/keyboard/SIKeyboard.c
+++ b/payload/sp/keyboard/SIKeyboard.c
@@ -13,9 +13,7 @@
 
 #include "SIKeyboard.h"
 
-#include <revolution.h>
 #include <revolution/si.h>
-#include <sp/ScopeLock.h>
 #include <sp/TypingBuffer.h>
 
 // Behaves like std::array<char, 3>

--- a/payload/sp/net/AsyncListener.hh
+++ b/payload/sp/net/AsyncListener.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <optional>
 

--- a/payload/sp/net/AsyncSocket.hh
+++ b/payload/sp/net/AsyncSocket.hh
@@ -2,9 +2,9 @@
 
 #include "sp/CircularBuffer.hh"
 
+#include <revolution.hh>
 extern "C" {
 #include <libhydrogen/hydrogen.h>
-#include <revolution.h>
 }
 
 namespace SP::Net {

--- a/payload/sp/net/SyncSocket.cc
+++ b/payload/sp/net/SyncSocket.cc
@@ -6,9 +6,7 @@ extern "C" {
 #include "sp/net/Net.hh"
 
 #include <common/Bytes.hh>
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 #include <cstring>
 

--- a/payload/sp/net/UnreliableSocket.hh
+++ b/payload/sp/net/UnreliableSocket.hh
@@ -2,7 +2,6 @@
 
 extern "C" {
 #include <libhydrogen/hydrogen.h>
-#include <revolution.h>
 }
 
 #include <optional>

--- a/payload/sp/security/StackCanary.c
+++ b/payload/sp/security/StackCanary.c
@@ -1,7 +1,5 @@
 #include "StackCanary.h"
 
-#include <Common.h>
-
 u32 __stack_chk_guard;
 
 static void SetIABRRegister(u32 value) {

--- a/payload/sp/security/StackCanary.hh
+++ b/payload/sp/security/StackCanary.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Common.h>
+#include <Common.hh>
 
 namespace SP::StackCanary {
 

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -1,6 +1,9 @@
 #include "ClientSettings.hh"
 
 #include <features/online/Online.hh>
+extern "C" {
+#include <vendor/libhydrogen/hydrogen.h>
+}
 
 #include <iterator>
 

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -3,9 +3,6 @@
 #include "sp/settings/Settings.hh"
 
 #include <game/util/Registry.hh>
-extern "C" {
-#include <vendor/libhydrogen/hydrogen.h>
-}
 
 namespace SP::ClientSettings {
 

--- a/payload/sp/settings/IniReader.cc
+++ b/payload/sp/settings/IniReader.cc
@@ -1,8 +1,6 @@
 #include "IniReader.hh"
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace SP {
 

--- a/payload/sp/settings/Settings.hh
+++ b/payload/sp/settings/Settings.hh
@@ -2,9 +2,7 @@
 
 #include "sp/settings/IniReader.hh"
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 #include <vendor/magic_enum/magic_enum.hpp>
 
 #include <cstdarg>

--- a/payload/sp/storage/DVDStorage.cc
+++ b/payload/sp/storage/DVDStorage.cc
@@ -1,5 +1,7 @@
 #include "DVDStorage.hh"
 
+#include <Common.hh>
+
 #include <cstring>
 
 namespace SP::Storage {

--- a/payload/sp/storage/DecompLoader.cc
+++ b/payload/sp/storage/DecompLoader.cc
@@ -158,12 +158,6 @@ bool LoadRO(const char *path, u8 **dst, size_t *dstSize, EGG::Heap *heap,
 
 } // namespace SP::Storage::DecompLoader
 
-extern "C" bool DecompLoader_Load(const char *path, u8 **dst, size_t *dstSize, EGG_Heap *heap) {
-    auto *eggHeap = reinterpret_cast<EGG::Heap *>(heap);
-    return SP::Storage::DecompLoader::Load(path, dst, dstSize, eggHeap);
-}
-
-extern "C" bool DecompLoader_LoadRO(const char *path, u8 **dst, size_t *dstSize, EGG_Heap *heap) {
-    auto *eggHeap = reinterpret_cast<EGG::Heap *>(heap);
-    return SP::Storage::DecompLoader::LoadRO(path, dst, dstSize, eggHeap);
+extern "C" bool DecompLoader_LoadRO(const char *path, u8 **dst, size_t *dstSize, EGG::Heap *heap) {
+    return SP::Storage::DecompLoader::LoadRO(path, dst, dstSize, heap);
 }

--- a/payload/sp/storage/DecompLoader.h
+++ b/payload/sp/storage/DecompLoader.h
@@ -2,5 +2,4 @@
 
 #include <egg/core/eggHeap.h>
 
-bool DecompLoader_Load(const char *path, u8 **dst, size_t *dstSize, EGG_Heap *heap);
 bool DecompLoader_LoadRO(const char *path, u8 **dst, size_t *dstSize, EGG_Heap *heap);

--- a/payload/sp/storage/DecompLoader.hh
+++ b/payload/sp/storage/DecompLoader.hh
@@ -1,11 +1,6 @@
 #pragma once
 
-extern "C" {
-#include "DecompLoader.h"
-}
-
 #include "sp/storage/Storage.hh"
-
 #include <egg/core/eggHeap.hh>
 
 namespace SP::Storage::DecompLoader {

--- a/payload/sp/storage/FATStorage.cc
+++ b/payload/sp/storage/FATStorage.cc
@@ -8,7 +8,6 @@ extern "C" {
 #include "sp/storage/UsbStorage.h"
 }
 
-#include <array>
 #include <cstring>
 
 namespace SP::Storage {

--- a/payload/sp/storage/Storage.hh
+++ b/payload/sp/storage/Storage.hh
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <optional>
-
-#include <Common.hh>
-
 #include <revolution.hh>
+
+#include <optional>
 
 namespace SP::Storage {
 

--- a/payload/sp/storage/Storage.hh
+++ b/payload/sp/storage/Storage.hh
@@ -4,9 +4,7 @@
 
 #include <Common.hh>
 
-extern "C" {
-#include <revolution.h>
-}
+#include <revolution.hh>
 
 namespace SP::Storage {
 

--- a/payload/sp/storage/UsbStorage.c
+++ b/payload/sp/storage/UsbStorage.c
@@ -16,7 +16,6 @@
 
 #include <revolution.h>
 
-#include <stdint.h>
 #include <string.h>
 
 enum {

--- a/tools/tidy/checks/__init__.py
+++ b/tools/tidy/checks/__init__.py
@@ -1,5 +1,7 @@
+from .duplicated_header import DuplicatedHeaderCheck
 from .pragma_once import PragmaOnceCheck
 
 checks = [
+    DuplicatedHeaderCheck("Check for revolution.h and Common.h includes"),
     PragmaOnceCheck("Ensure #pragma once is used in headers"),
 ]

--- a/tools/tidy/checks/duplicated_header.py
+++ b/tools/tidy/checks/duplicated_header.py
@@ -1,0 +1,18 @@
+from abstract_check import Check
+from typing import Optional
+from pathlib import Path
+
+__all__ = ["DuplicatedHeaderCheck"]
+
+class DuplicatedHeaderCheck(Check):
+    def run(self, files: list[Path]) -> Optional[Path]:
+        for file in files:
+            if file.suffix not in (".h", ".c", ".hh", ".cc"):
+                continue
+
+            text = file.read_text()
+            if "revolution.h>" in text and file.suffix in (".hh", ".cc"):
+                return file
+
+            if "revolution.h" in text and "Common.h" in text:
+                return file


### PR DESCRIPTION
- Removes unnecessary includes from the common files
- Removes duplicate includes from common and files that already included common
- Removes includes for `revolution.h` and `Common.h`(`h`) when not necessary 