### PR TITLE
Rename configure.py -> build.py and make responsible for invoking ninja 

### DIFF
--- a/.github/workflows/build_sp.yml
+++ b/.github/workflows/build_sp.yml
@@ -56,10 +56,8 @@ jobs:
         run: pip install itanium_demangler
       - name: Install protobuf
         run: pip install protobuf
-      - name: Configure ninja
-        run: ./configure.py --ci --default-targets ${{ matrix.profile }}
       - name: Compile
-        run: ninja
+        run: ./build.py --ci -- ${{ matrix.profile }}
       - name: Upload result
         uses: actions/upload-artifact@v3
         with: 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 build.ninja
+build.ninja.old
 __pycache__
 out
 .vs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 build
 build.ninja
-build.ninja.old
 __pycache__
 out
 .vs

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Compile the project by running `build.py`:
 
 The `out` directory will contain the generated binaries and assets.
 
-The `configure.py` command only needs to be run when a file has been added or removed
-to the project, and can be skipped if only recompiling with changed files.
-
 ## Contributing
 
 If you are working on something please comment on the relevant issue (or open a new one if necessary).
@@ -33,9 +30,7 @@ The codebase uses both C and asm, C should be preferred for full function replac
 
 The codebase is automatically formatted using `clang-format` (15), this will be checked by CI and must be run before merge.
 
-If you need a unoptimised build with debugging information, use `ninja debug` to build once, or use
-`configure.py --default-targets` and then a comma seperated list of `test`, `debug`, or `release` to
-automatically build the requested binaries with every `ninja` invoke.
+If you need a unoptimised build with debugging information, use `python3 build.py -- debug`.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,9 @@ You need:
 - itanium\_demangler
 - protobuf (the Python package)
 
-Generate the ninja file:
-
+Compile the project by running `build.py`:
 ```bash
-./configure.py
-```
-
-Execute it:
-
-```bash
-ninja
+./build.py
 ```
 
 The `out` directory will contain the generated binaries and assets.

--- a/build.py
+++ b/build.py
@@ -28,7 +28,6 @@ our_argv = []
 ninja_argv = []
 found_seperator = False
 for arg in sys.argv[1:]:
-    print(arg)
     if found_seperator or arg == "--":
         ninja_argv.append(arg)
         found_seperator = True

--- a/build.py
+++ b/build.py
@@ -37,7 +37,6 @@ for arg in sys.argv[1:]:
 
 parser = ArgumentParser()
 parser.add_argument('--gdb_compatible', action='store_true')
-parser.add_argument('--default-targets', default='test')
 parser.add_argument("--dry", action="store_true")
 parser.add_argument("--ci", action="store_true")
 args = parser.parse_args(our_argv)
@@ -1502,9 +1501,6 @@ n.build(
         'release',
     ],
 )
-n.newline()
-
-n.default(args.default_targets.split(','))
 n.newline()
 
 if args.dry:

--- a/build.py
+++ b/build.py
@@ -28,8 +28,9 @@ our_argv = []
 ninja_argv = []
 found_seperator = False
 for arg in sys.argv[1:]:
-    if found_seperator or arg == "--":
+    if found_seperator:
         ninja_argv.append(arg)
+    elif arg == "--":
         found_seperator = True
     else:
         our_argv.append(arg)

--- a/build.py
+++ b/build.py
@@ -1513,10 +1513,6 @@ if args.dry:
 
     raise SystemExit
 
-if os.path.exists("build.ninja"):
-    os.rename("build.ninja", "build.ninja.old")
-
-
 with tempfile.NamedTemporaryFile("w+") as out_file:
     out_file.write(out_buf.getvalue())
     n.close()


### PR DESCRIPTION
This prevents issues of the `build.ninja` file becoming out of sync with reality by making `build.ninja` entirely temporary using the builtin `tempfile` library, then passing the path to this temporary file directly to `ninja`. This responsiblity change also allows for more complex logic to be built around the ninja invokation, since we control it.

For manual inspection of the resulting temporary file, `--dry` has been added to `build.py` which will produce the `build.ninja` in the current directory, although this will not be used for builds.

One issue that could arise is that people continue to run `ninja` with versions of `build.ninja` from before this change, although that should pretty quickly break and we can just tell them to use `build.py`.