### PR TITLE
Workaround dol hashing issues on latest devkitpro

### DIFF
--- a/vendor/sha1/sha1.c
+++ b/vendor/sha1/sha1.c
@@ -30,14 +30,7 @@ A million repetitions of "a"
 
 /* blk0() and blk() perform the initial expand. */
 /* I got the idea of expanding during the round function from SSLeay */
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define blk0(i) (block->l[i] = (rol(block->l[i],24)&0xFF00FF00) \
-    |(rol(block->l[i],8)&0x00FF00FF))
-#elif BYTE_ORDER == BIG_ENDIAN
 #define blk0(i) block->l[i]
-#else
-#error "Endianness not defined!"
-#endif
 #define blk(i) (block->l[i&15] = rol(block->l[(i+13)&15]^block->l[(i+8)&15] \
     ^block->l[(i+2)&15]^block->l[i&15],1))
 


### PR DESCRIPTION
Seems like latest gcc breaks sha1 checking for little endian for some reason, leading to dol verification issues, this PR just works around it by hard coding big endian behavior but this should be looked into more.