### PR TITLE
Reimplement KartSaveState cleaner

### DIFF
--- a/payload/game/kart/KartBoost.hh
+++ b/payload/game/kart/KartBoost.hh
@@ -8,8 +8,11 @@ class KartBoost {
     friend class KartObjectProxy;
     friend class KartRollback;
 
+public:
+    KartBoost();
+    virtual ~KartBoost();
+
 private:
-    u8 _00[0x04 - 0x00];
     s16 m_timesBeforeEnd[6];
     u16 m_types;
     u8 _12[0x24 - 0x12];

--- a/payload/game/kart/KartBoost.hh
+++ b/payload/game/kart/KartBoost.hh
@@ -7,16 +7,22 @@ namespace Kart {
 class KartBoost {
     friend class KartObjectProxy;
     friend class KartRollback;
+    friend class KartSaveState;
 
 public:
     KartBoost();
-    virtual ~KartBoost();
+    virtual ~KartBoost() = delete;
+    virtual void dt(s32 type);
 
 private:
     s16 m_timesBeforeEnd[6];
     u16 m_types;
-    u8 _12[0x24 - 0x12];
+    f32 m_boostMultipler;
+    f32 m_boostAcceleration;
+    f32 m_1c;
+    f32 m_boostSpeedLimit;
 };
+
 static_assert(sizeof(KartBoost) == 0x24);
 
 } // namespace Kart

--- a/payload/game/kart/KartMove.hh
+++ b/payload/game/kart/KartMove.hh
@@ -8,6 +8,7 @@ namespace Kart {
 class KartMove : public KartObjectProxy {
     friend class KartObjectProxy;
     friend class KartRollback;
+    friend class KartSaveState;
 
 public:
     f32 hardSpeedLimit() const;

--- a/payload/game/kart/KartSaveState.cc
+++ b/payload/game/kart/KartSaveState.cc
@@ -7,46 +7,38 @@ KartSaveState::KartSaveState(KartAccessor accessor, VehiclePhysics *physics, Kar
 }
 
 void KartSaveState::save(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
-    m_item = *item;
-    m_physics = *physics;
-    m_5c = *accessor.unk5c;
-    m_sub = *accessor.sub;
-    m_body = *accessor.body;
-    m_move = *accessor.move;
-    m_state = *accessor.state;
-    m_action = *accessor.action;
-    m_collide = *accessor.collide;
+    m_externalVel = physics->m_externalVel;
+    m_internalVel = physics->m_internalVel;
+    m_mainRot = physics->m_mainRot;
+    m_pos = physics->m_pos;
 
-    for (u8 i = 0; i < accessor.settings->susCount; i++) {
-        m_sus[i].base = *accessor.sus[i];
-        m_sus[i].physics = *accessor.sus[i]->m_physics;
-    }
+    m_internalSpeed = accessor.move->m_internalSpeed;
+    m_boostState = accessor.move->m_boost;
+
+    m_item = *item;
 
     for (u8 i = 0; i < accessor.settings->tireCount; i++) {
-        m_tire[i].tire = *accessor.tire[i];
-        m_tire[i].physics = *accessor.tire[i]->m_wheelPhysics;
+        m_wheelPhysics[i].m_realPos = accessor.tire[i]->m_wheelPhysics->m_realPos;
+        m_wheelPhysics[i].m_lastPos = accessor.tire[i]->m_wheelPhysics->m_lastPos;
+        m_wheelPhysics[i].m_lastPosDiff = accessor.tire[i]->m_wheelPhysics->m_lastPosDiff;
     }
 }
 
 void KartSaveState::reload(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
-    *item = m_item;
-    *physics = m_physics;
-    *accessor.sub = m_sub;
-    *accessor.unk5c = m_5c;
-    *accessor.body = m_body;
-    *accessor.move = m_move;
-    *accessor.state = m_state;
-    *accessor.action = m_action;
-    *accessor.collide = m_collide;
+    physics->m_externalVel = m_externalVel;
+    physics->m_internalVel = m_internalVel;
+    physics->m_mainRot = m_mainRot;
+    physics->m_pos = m_pos;
 
-    for (u8 i = 0; i < accessor.settings->susCount; i++) {
-        *accessor.sus[i] = m_sus[i].base;
-        *accessor.sus[i]->m_physics = m_sus[i].physics;
-    }
+    accessor.move->m_internalSpeed = m_internalSpeed;
+    accessor.move->m_boost = m_boostState;
+
+    *item = m_item;
 
     for (u8 i = 0; i < accessor.settings->tireCount; i++) {
-        *accessor.tire[i] = m_tire[i].tire;
-        *accessor.tire[i]->m_wheelPhysics = m_tire[i].physics;
+        accessor.tire[i]->m_wheelPhysics->m_realPos = m_wheelPhysics[i].m_realPos;
+        accessor.tire[i]->m_wheelPhysics->m_lastPos = m_wheelPhysics[i].m_lastPos;
+        accessor.tire[i]->m_wheelPhysics->m_lastPosDiff = m_wheelPhysics[i].m_lastPosDiff;
     }
 }
 

--- a/payload/game/kart/KartSaveState.cc
+++ b/payload/game/kart/KartSaveState.cc
@@ -1,5 +1,7 @@
 #include "KartSaveState.hh"
 
+#include <cstring>
+
 namespace Kart {
 
 KartSaveState::KartSaveState(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
@@ -13,7 +15,11 @@ void KartSaveState::save(KartAccessor accessor, VehiclePhysics *physics, KartIte
     m_pos = physics->m_pos;
 
     m_internalSpeed = accessor.move->m_internalSpeed;
-    m_boostState = accessor.move->m_boost;
+    m_boostState.m_types = accessor.move->m_boost.m_types;
+    m_boostState.m_boostMultipler = accessor.move->m_boost.m_boostMultipler;
+    m_boostState.m_boostAcceleration = accessor.move->m_boost.m_boostAcceleration;
+    m_boostState.m_1c = accessor.move->m_boost.m_1c;
+    m_boostState.m_boostSpeedLimit = accessor.move->m_boost.m_boostSpeedLimit;
 
     m_item = *item;
 
@@ -31,7 +37,11 @@ void KartSaveState::reload(KartAccessor accessor, VehiclePhysics *physics, KartI
     physics->m_pos = m_pos;
 
     accessor.move->m_internalSpeed = m_internalSpeed;
-    accessor.move->m_boost = m_boostState;
+    accessor.move->m_boost.m_types = m_boostState.m_types;
+    accessor.move->m_boost.m_boostMultipler = m_boostState.m_boostMultipler;
+    accessor.move->m_boost.m_boostAcceleration = m_boostState.m_boostAcceleration;
+    accessor.move->m_boost.m_1c = m_boostState.m_1c;
+    accessor.move->m_boost.m_boostSpeedLimit = m_boostState.m_boostSpeedLimit;
 
     *item = m_item;
 

--- a/payload/game/kart/KartSaveState.hh
+++ b/payload/game/kart/KartSaveState.hh
@@ -1,19 +1,14 @@
-// Handles storing and restoring as much state about the kart as possible
+// Handles storing and restoring as much state about the kart as needed
 // to allow for faster dolphin-like save states on console for practicing.
 //
 // This class is only for low level management, further functionality should
 // most likely be added to SP::SaveStateManager.
 
 #pragma once
-#include "Kart5c.hh"
-#include "KartAction.hh"
-#include "KartBody.hh"
-#include "KartCollide.hh"
+
+#include "KartBoost.hh"
 #include "KartMove.hh"
-#include "KartSettings.hh"
-#include "KartState.hh"
-#include "KartSub.hh"
-#include "KartSus.hh"
+#include "KartObjectManager.hh"
 #include "KartTire.hh"
 #include "VehiclePhysics.hh"
 
@@ -23,14 +18,10 @@ extern "C" {
 
 namespace Kart {
 
-struct KartSusFlat {
-    KartSus base;
-    KartSusPhysics physics;
-};
-
-struct KartTireFlat {
-    KartTire tire;
-    WheelPhysics physics;
+struct MinifiedWheelPhysics {
+    Vec3 m_realPos;
+    Vec3 m_lastPos;
+    Vec3 m_lastPosDiff;
 };
 
 class KartSaveState {
@@ -41,16 +32,18 @@ public:
     void reload(KartAccessor accessor, VehiclePhysics *physics, KartItem *item);
 
 private:
-    Kart5c m_5c;
-    KartSub m_sub;
-    KartBody m_body;
-    KartMove m_move;
-    KartState m_state;
-    KartAction m_action;
-    KartSusFlat m_sus[4];
-    KartTireFlat m_tire[4];
-    KartCollide m_collide;
-    VehiclePhysics m_physics;
+    // VehiclePhysics
+    Vec3 m_externalVel;
+    Vec3 m_internalVel;
+    Quat m_mainRot;
+    Vec3 m_pos;
+
+    // KartMove
+    f32 m_internalSpeed;
+    KartBoost m_boostState;
+
+    MinifiedWheelPhysics m_wheelPhysics[4];
+
     KartItem m_item;
 };
 

--- a/payload/game/kart/KartSaveState.hh
+++ b/payload/game/kart/KartSaveState.hh
@@ -18,6 +18,18 @@ extern "C" {
 
 namespace Kart {
 
+// KartBoost's constructor cannot be patched to replace
+// the vtable, and therefore define a GCC destructor
+// as it is inlined in KartMove.
+struct PODKartBoost {
+    s16 m_timesBeforeEnd[6];
+    u16 m_types;
+    f32 m_boostMultipler;
+    f32 m_boostAcceleration;
+    f32 m_1c;
+    f32 m_boostSpeedLimit;
+};
+
 struct MinifiedWheelPhysics {
     Vec3 m_realPos;
     Vec3 m_lastPos;
@@ -40,7 +52,7 @@ private:
 
     // KartMove
     f32 m_internalSpeed;
-    KartBoost m_boostState;
+    PODKartBoost m_boostState;
 
     MinifiedWheelPhysics m_wheelPhysics[4];
 

--- a/payload/game/kart/KartTire.hh
+++ b/payload/game/kart/KartTire.hh
@@ -1,12 +1,30 @@
 #pragma once
 
 #include "KartObjectManager.hh"
+#include "KartPart.hh"
 
 namespace Kart {
 
 class WheelPhysics : public KartObjectProxy {
+    friend class KartSaveState;
+
 private:
-    u8 _0c[0x84 - 0x0c];
+    WheelPhysics();
+    virtual ~WheelPhysics();
+    virtual void dt(s32 type);
+
+    u32 m_wheelIdx;
+    u32 m_bspWheelIdx;
+    void *m_bspWheel;
+    void *m_colisionGroup;
+    Vec3 m_realPos;
+    Vec3 m_lastPos;
+    Vec3 m_lastPosDiff;
+    f32 m_yDown;
+    Vec3 _48;
+    Vec3 m_speed;
+
+    u8 _10[0x84 - 0x60];
 };
 
 class KartTire : public KartPart {

--- a/payload/game/kart/VehiclePhysics.hh
+++ b/payload/game/kart/VehiclePhysics.hh
@@ -8,6 +8,7 @@ namespace Kart {
 class VehiclePhysics {
     friend class KartObjectProxy;
     friend class KartRollback;
+    friend class KartSaveState;
 
 public:
     const Vec3 *externalVel() const;

--- a/symbols.txt
+++ b/symbols.txt
@@ -651,6 +651,8 @@
 0x80581824 _ZN4Kart8KartMove9calcBlinkEv
 0x80584d58 KartMove_calcCannon
 0x805858ac KartMove_startKiller
+0x80588d28 _ZN4Kart9KartBoostC1Ev
+0x8057811c _ZN4Kart9KartBoostD1Ev
 0x8058e22c _ZN4Kart10KartObject4initEv
 0x8058eeb4 _ZN4Kart10KartObject9calcEarlyEv
 0x8058eebc KartObject_calcPass1

--- a/symbols.txt
+++ b/symbols.txt
@@ -651,8 +651,6 @@
 0x80581824 _ZN4Kart8KartMove9calcBlinkEv
 0x80584d58 KartMove_calcCannon
 0x805858ac KartMove_startKiller
-0x80588d28 _ZN4Kart9KartBoostC1Ev
-0x8057811c _ZN4Kart9KartBoostD1Ev
 0x8058e22c _ZN4Kart10KartObject4initEv
 0x8058eeb4 _ZN4Kart10KartObject9calcEarlyEv
 0x8058eebc KartObject_calcPass1


### PR DESCRIPTION
This reimplements `KartSaveState` using a cleaner design, storing the minimum amount of data instead of trying to store everything (which contains pointers).

I've tested this doesn't store any pointers by moving `SaveStateManager` to static memory, then simply not resetting the `KartSaveState` when reloading the scene, and it works without crashing.

I could remove the headers added by `KartSaveState`, but they could be useful for future development, so opinions are wanted.

Closes #710 as the implementation is no longer such a hack.