### PR TITLE
Implement vanilla vehicle restrictions

### DIFF
--- a/payload/game/ui/GlobalContext.cc
+++ b/payload/game/ui/GlobalContext.cc
@@ -28,4 +28,27 @@ void GlobalContext::onChangeLicense() {
     SP::CourseDatabase::Instance().resetSelection();
 }
 
+void GlobalContext::applyVehicleRestriction(bool isBattle) {
+    auto *saveManager = System::SaveManager::Instance();
+
+    SP::ClientSettings::Vehicles setting;
+    if (isBattle) {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::BTVehicles>();
+    } else {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::VSVehicles>();
+    }
+
+    switch (setting) {
+    case SP::ClientSettings::Vehicles::All:
+        m_vehicleRestriction = VehicleRestriction::All;
+        break;
+    case SP::ClientSettings::Vehicles::Karts:
+        m_vehicleRestriction = VehicleRestriction::KartsOnly;
+        break;
+    case SP::ClientSettings::Vehicles::Bikes:
+        m_vehicleRestriction = VehicleRestriction::BikesOnly;
+        break;
+    }
+}
+
 } // namespace UI

--- a/payload/game/ui/GlobalContext.hh
+++ b/payload/game/ui/GlobalContext.hh
@@ -29,11 +29,17 @@ public:
         u32 m_errorCode;
     };
 
+    enum class VehicleRestriction: u32 {
+        KartsOnly = 0,
+        BikesOnly = 1,
+        All = 2
+    };
+
     u8 _000[0x060 - 0x000];
     u32 m_match;
     u32 m_matchCount;
     u8 _068[0x074 - 0x068];
-    u32 _74;
+    VehicleRestriction m_vehicleRestriction;
     u8 _078[0x124 - 0x078];
     u32 m_localPlayerCount;
     u8 _128[0x12c - 0x128];

--- a/payload/game/ui/GlobalContext.hh
+++ b/payload/game/ui/GlobalContext.hh
@@ -18,6 +18,8 @@ public:
     void REPLACED(onChangeLicense)();
     REPLACE void onChangeLicense();
 
+    void applyVehicleRestriction(bool isBattle);
+
     struct SelectPlayer {
         u32 m_characterId;
         u32 m_vehicleId;

--- a/payload/game/ui/GlobalContext.hh
+++ b/payload/game/ui/GlobalContext.hh
@@ -29,11 +29,7 @@ public:
         u32 m_errorCode;
     };
 
-    enum class VehicleRestriction: u32 {
-        KartsOnly = 0,
-        BikesOnly = 1,
-        All = 2
-    };
+    enum class VehicleRestriction : u32 { KartsOnly = 0, BikesOnly = 1, All = 2 };
 
     u8 _000[0x060 - 0x000];
     u32 m_match;

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -63,9 +63,6 @@ void MultiTopPage::onInit() {
 void MultiTopPage::onActivate() {
     m_replacement = PageId::None;
 
-    auto *context = SectionManager::Instance()->globalContext();
-    context->m_vehicleRestriction = GlobalContext::VehicleRestriction::All;
-
     if (m_reset) {
         m_vsButton.selectDefault(0);
         m_instructionText.setMessage(3052);
@@ -130,6 +127,7 @@ void MultiTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */) 
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
 
+    context->applyVehicleRestriction(false);
     raceConfig->applyCPUMode();
     raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();
@@ -178,6 +176,7 @@ void MultiTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */) 
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
 
+    context->applyVehicleRestriction(true);
     raceConfig->applyEngineClass();
     raceConfig->applyCPUMode();
     raceConfig->applyItemFreq();

--- a/payload/game/ui/MultiTopPage.cc
+++ b/payload/game/ui/MultiTopPage.cc
@@ -64,7 +64,7 @@ void MultiTopPage::onActivate() {
     m_replacement = PageId::None;
 
     auto *context = SectionManager::Instance()->globalContext();
-    context->_74 = 2;
+    context->m_vehicleRestriction = GlobalContext::VehicleRestriction::All;
 
     if (m_reset) {
         m_vsButton.selectDefault(0);

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -16,6 +16,30 @@ extern "C" {
 
 namespace UI {
 
+static void applyVehicleRestriction(bool isBattle) {
+    auto *saveManager = System::SaveManager::Instance();
+
+    SP::ClientSettings::Vehicles setting;
+    if (isBattle) {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::BTVehicles>();
+    } else {
+        setting = saveManager->getSetting<SP::ClientSettings::Setting::VSVehicles>();
+    }
+
+    auto *globalContext = SectionManager::Instance()->globalContext();
+    switch (setting) {
+    case SP::ClientSettings::Vehicles::All:
+        globalContext->m_vehicleRestriction = GlobalContext::VehicleRestriction::All;
+        break;
+    case SP::ClientSettings::Vehicles::Karts:
+        globalContext->m_vehicleRestriction = GlobalContext::VehicleRestriction::KartsOnly;
+        break;
+    case SP::ClientSettings::Vehicles::Bikes:
+        globalContext->m_vehicleRestriction = GlobalContext::VehicleRestriction::BikesOnly;
+        break;
+    }
+}
+
 SingleTopPage::SingleTopPage() = default;
 
 SingleTopPage::~SingleTopPage() = default;
@@ -93,9 +117,6 @@ void SingleTopPage::onInit() {
 
 void SingleTopPage::onActivate() {
     m_replacement = PageId::None;
-
-    auto *context = SectionManager::Instance()->globalContext();
-    context->_74 = 2;
 
     auto &menuScenario = System::RaceConfig::Instance()->menuScenario();
     menuScenario.itemMode = 0;
@@ -178,6 +199,7 @@ void SingleTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */)
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
 
+    applyVehicleRestriction(false);
     raceConfig->applyCPUMode();
     raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();
@@ -223,6 +245,7 @@ void SingleTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */)
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
 
+    applyVehicleRestriction(true);
     raceConfig->applyCPUMode();
     raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();

--- a/payload/game/ui/SingleTopPage.cc
+++ b/payload/game/ui/SingleTopPage.cc
@@ -16,30 +16,6 @@ extern "C" {
 
 namespace UI {
 
-static void applyVehicleRestriction(bool isBattle) {
-    auto *saveManager = System::SaveManager::Instance();
-
-    SP::ClientSettings::Vehicles setting;
-    if (isBattle) {
-        setting = saveManager->getSetting<SP::ClientSettings::Setting::BTVehicles>();
-    } else {
-        setting = saveManager->getSetting<SP::ClientSettings::Setting::VSVehicles>();
-    }
-
-    auto *globalContext = SectionManager::Instance()->globalContext();
-    switch (setting) {
-    case SP::ClientSettings::Vehicles::All:
-        globalContext->m_vehicleRestriction = GlobalContext::VehicleRestriction::All;
-        break;
-    case SP::ClientSettings::Vehicles::Karts:
-        globalContext->m_vehicleRestriction = GlobalContext::VehicleRestriction::KartsOnly;
-        break;
-    case SP::ClientSettings::Vehicles::Bikes:
-        globalContext->m_vehicleRestriction = GlobalContext::VehicleRestriction::BikesOnly;
-        break;
-    }
-}
-
 SingleTopPage::SingleTopPage() = default;
 
 SingleTopPage::~SingleTopPage() = default;
@@ -199,7 +175,7 @@ void SingleTopPage::onVSButtonFront(PushButton *button, u32 /* localPlayerId */)
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
 
-    applyVehicleRestriction(false);
+    context->applyVehicleRestriction(false);
     raceConfig->applyCPUMode();
     raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();
@@ -245,7 +221,7 @@ void SingleTopPage::onBTButtonFront(PushButton *button, u32 /* localPlayerId */)
         menuScenario.players[i].type = System::RaceConfig::Player::Type::CPU;
     }
 
-    applyVehicleRestriction(true);
+    context->applyVehicleRestriction(true);
     raceConfig->applyCPUMode();
     raceConfig->applyItemFreq();
     raceConfig->applyEngineClass();

--- a/payload/sp/settings/ClientSettings.cc
+++ b/payload/sp/settings/ClientSettings.cc
@@ -403,8 +403,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(Vehicles::All),
         .valueCount = magic_enum::enum_count<Vehicles>(),
         .valueNames = magic_enum::enum_names<Vehicles>().data(),
-        .valueMessageIds = (u32[]) { 10244, 10245, 10246, 10247, 10248, 10249, 10250 },
-        .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, 10254, 10255, 10256, 10257 },
+        .valueMessageIds = (u32[]) { 10244, 10245, 10246, /* 10247, 10248, 10249, 10250 */ },
+        .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, /* 10254, 10255, 10256, 10257 */ },
     },
     [static_cast<u32>(Setting::VSItemFrequency)] = {
         .category = Category::VS,
@@ -474,8 +474,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(Vehicles::All),
         .valueCount = magic_enum::enum_count<Vehicles>(),
         .valueNames = magic_enum::enum_names<Vehicles>().data(),
-        .valueMessageIds = (u32[]) { 10244, 10245, 10246, 10247, 10248, 10249, 10250 },
-        .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, 10254, 10255, 10256, 10257 },
+        .valueMessageIds = (u32[]) { 10244, 10245, 10246, /* 10247, 10248, 10249, 10250 */ },
+        .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, /* 10254, 10255, 10256, 10257 */ },
     },
     [static_cast<u32>(Setting::BTItemFrequency)] = {
         .category = Category::BT,
@@ -550,8 +550,8 @@ const Entry entries[] = {
         .defaultValue = static_cast<u32>(Vehicles::All),
         .valueCount = magic_enum::enum_count<Vehicles>(),
         .valueNames = magic_enum::enum_names<Vehicles>().data(),
-        .valueMessageIds = (u32[]) { 10244, 10245, 10246, 10247, 10248, 10249, 10250 },
-        .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, 10254, 10255, 10256, 10257 },
+        .valueMessageIds = (u32[]) { 10244, 10245, 10246, /* 10247, 10248, 10249, 10250 */ },
+        .valueExplanationMessageIds = (u32[]) { 10251, 10252, 10253, /* 10254, 10255, 10256, 10257 */ },
         .hidden = !ENABLE_ONLINE,
     },
     [static_cast<u32>(Setting::RoomCodeHigh)] = {

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -127,6 +127,10 @@ enum class Vehicles {
     All,
     Karts,
     Bikes,
+    // InsideDrift,
+    // OutsideDrift,
+    // Optimal,
+    // Random,
 };
 
 enum class ItemFrequency {

--- a/payload/sp/settings/ClientSettings.hh
+++ b/payload/sp/settings/ClientSettings.hh
@@ -127,10 +127,6 @@ enum class Vehicles {
     All,
     Karts,
     Bikes,
-    InsideDrift,
-    OutsideDrift,
-    Optimal,
-    Random,
 };
 
 enum class ItemFrequency {


### PR DESCRIPTION
Part of the fix for #667, undoes the regression made by adding the new settings menu, but does not implement further filtering due to added complexity.