### PR TITLE
Savestates: Sync more bullet state

### DIFF
--- a/payload/game/kart/KartBullet.hh
+++ b/payload/game/kart/KartBullet.hh
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "game/kart/KartObjectProxy.hh"
+
+namespace Kart {
+
+class KartBullet : public KartObjectProxy {
+public:
+    void activateBullet(u32 r4);
+    void cancelBullet();
+
+private:
+    u8 _0c[0x64 - 0x0c];
+};
+
+static_assert(sizeof(KartBullet) == 0x64);
+
+} // namespace Kart

--- a/payload/game/kart/KartObjectProxy.hh
+++ b/payload/game/kart/KartObjectProxy.hh
@@ -15,6 +15,7 @@ namespace Kart {
 
 class KartAction;
 class KartBody;
+class KartBullet;
 class KartCollide;
 class KartMove;
 class KartRollback;
@@ -40,7 +41,8 @@ struct KartAccessor {
     KartCollide *collide;
     u8 _34[0x3c - 0x34];
     KartRollback *rollback; // Replaced
-    u8 _40[0x64 - 0x40];
+    u8 _40[0x60 - 0x40];
+    KartBullet *bullet;
 };
 
 static_assert(sizeof(KartAccessor) == 0x64);

--- a/payload/game/kart/KartSaveState.cc
+++ b/payload/game/kart/KartSaveState.cc
@@ -1,5 +1,7 @@
 #include "KartSaveState.hh"
 
+#include "game/kart/KartBullet.hh"
+
 #include <cstring>
 
 namespace Kart {
@@ -11,6 +13,7 @@ KartSaveState::KartSaveState(KartAccessor accessor, VehiclePhysics *physics, Kar
 void KartSaveState::save(KartAccessor accessor, VehiclePhysics *physics, KartItem *item) {
     m_externalVel = physics->m_externalVel;
     m_internalVel = physics->m_internalVel;
+    m_inBullet = physics->m_inBullet;
     m_mainRot = physics->m_mainRot;
     m_pos = physics->m_pos;
 
@@ -49,6 +52,12 @@ void KartSaveState::reload(KartAccessor accessor, VehiclePhysics *physics, KartI
         accessor.tire[i]->m_wheelPhysics->m_realPos = m_wheelPhysics[i].m_realPos;
         accessor.tire[i]->m_wheelPhysics->m_lastPos = m_wheelPhysics[i].m_lastPos;
         accessor.tire[i]->m_wheelPhysics->m_lastPosDiff = m_wheelPhysics[i].m_lastPosDiff;
+    }
+
+    if (physics->m_inBullet && !m_inBullet) {
+        accessor.bullet->cancelBullet();
+    } else if (!physics->m_inBullet && m_inBullet) {
+        accessor.bullet->activateBullet(0xFF);
     }
 }
 

--- a/payload/game/kart/KartSaveState.hh
+++ b/payload/game/kart/KartSaveState.hh
@@ -47,6 +47,7 @@ private:
     // VehiclePhysics
     Vec3 m_externalVel;
     Vec3 m_internalVel;
+    bool m_inBullet;
     Quat m_mainRot;
     Vec3 m_pos;
 

--- a/payload/game/kart/VehiclePhysics.hh
+++ b/payload/game/kart/VehiclePhysics.hh
@@ -28,7 +28,9 @@ private:
     Quat m_mainRot;
     u8 _100[0x14c - 0x100];
     Vec3 m_internalVel;
-    u8 _158[0x1b4 - 0x158];
+    u8 _158[0x174 - 0x158];
+    bool m_inBullet;
+    u8 _175[0x1b4 - 0x175];
 };
 static_assert(sizeof(VehiclePhysics) == 0x1b4);
 

--- a/symbols.txt
+++ b/symbols.txt
@@ -708,6 +708,8 @@
 0x80596cfc KartSub_calcPass1
 0x8059783c KartSub_calcTransforms
 0x8059BC44 KartKiller_calcTracking
+0x8059b7b8 _ZN4Kart10KartBullet14activateBulletEj
+0x8059c118 _ZN4Kart10KartBullet12cancelBulletEv
 0x8059e250 _ZN2UI16MenuModelManager4initEjPFvaE
 0x805a1d10 Camera_805a1d10
 0x805a2034 Camera_805a2034


### PR DESCRIPTION
Syncs buillets by just calling the activate and cancel methods on KartBullet. From quick testing, this works for `bullet -> not` and `not -> bullet` but goes in the wrong direction for a short time before recalculating for `bullet -> bullet`.