### PR TITLE
Fix 200cc brake drifting

### DIFF
--- a/payload/game/effect/Effect.S
+++ b/payload/game/effect/Effect.S
@@ -4,8 +4,8 @@ PATCH_B_START(Effect_80698028, 0xf24)
     bl Effect_806979f0 // Original instruction
 
     // Check that 200cc is enabled
-    lis r3, speedModIsEnabled@ha
-    lbz r3, speedModIsEnabled@l (r3)
+    lis r3, g_speedModIsEnabled@ha
+    lbz r3, g_speedModIsEnabled@l (r3)
     cmpwi r3, 0x0
     beq .LendKart
 
@@ -80,8 +80,8 @@ PATCH_B_END(Effect_80698028, 0xf24)
 
 PATCH_B_START(Effect_80698f70, 0xd28)
     // Check that 200cc is enabled
-    lis r3, speedModIsEnabled@ha
-    lbz r3, speedModIsEnabled@l (r3)
+    lis r3, g_speedModIsEnabled@ha
+    lbz r3, g_speedModIsEnabled@l (r3)
     cmpwi r3, 0x0
     beq .LendBike
 

--- a/payload/game/item/ItemObjKouraAka.S
+++ b/payload/game/item/ItemObjKouraAka.S
@@ -3,8 +3,8 @@
 PATCH_B_START(ItemObjKouraAka_vf_20, 0x128)
     mr r3, r29 // Original instruction
 
-    lis r5, speedModFactor@ha
-    lfs f2, speedModFactor@l (r5)
+    lis r5, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r5)
     fmuls f1, f1, f2
     b ItemObjKouraAka_vf_20 + 0x12c
 PATCH_B_END(ItemObjKouraAka_vf_20, 0x128)
@@ -12,8 +12,8 @@ PATCH_B_END(ItemObjKouraAka_vf_20, 0x128)
 PATCH_B_START(ItemObjKouraAka_vf_20, 0x158)
     mr r3, r29 // Original instruction
 
-    lis r5, speedModFactor@ha
-    lfs f2, speedModFactor@l (r5)
+    lis r5, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r5)
     fmuls f1, f1, f2
     b ItemObjKouraAka_vf_20 + 0x15c
 PATCH_B_END(ItemObjKouraAka_vf_20, 0x158)
@@ -21,8 +21,8 @@ PATCH_B_END(ItemObjKouraAka_vf_20, 0x158)
 PATCH_B_START(ItemObjKouraAka_807aae78, 0x9c)
     mr r3, r31 // Original instruction
 
-    lis r5, speedModFactor@ha
-    lfs f3, speedModFactor@l (r5)
+    lis r5, g_speedModFactor@ha
+    lfs f3, g_speedModFactor@l (r5)
     fmuls f1, f1, f3
     b ItemObjKouraAka_807aae78 + 0xa0
 PATCH_B_END(ItemObjKouraAka_807aae78, 0x9c)

--- a/payload/game/item/ItemObjKouraAo.S
+++ b/payload/game/item/ItemObjKouraAo.S
@@ -3,8 +3,8 @@
 PATCH_B_START(ItemObjKouraAo_807ac49c, 0xcc)
     mr r3, r30 // Original instruction
 
-    lis r4, speedModFactor@ha
-    lfs f7, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f7, g_speedModFactor@l (r4)
     fmuls f3, f3, f7
     b ItemObjKouraAo_807ac49c + 0xd0
 PATCH_B_END(ItemObjKouraAo_807ac49c, 0xcc)
@@ -12,8 +12,8 @@ PATCH_B_END(ItemObjKouraAo_807ac49c, 0xcc)
 PATCH_B_START(ItemObjKouraAo_807ad5a4, 0x18)
     mr r31, r3 // Original instruction
 
-    lis r4, speedModFactor@ha
-    lfs f2, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r4)
     fmuls f1, f1, f2
     b ItemObjKouraAo_807ad5a4 + 0x1c
 PATCH_B_END(ItemObjKouraAo_807ad5a4, 0x18)
@@ -21,8 +21,8 @@ PATCH_B_END(ItemObjKouraAo_807ad5a4, 0x18)
 PATCH_B_START(ItemObjKouraAo_807ad824, 0x24)
     lfs f2, 0x2f0 (r31) // Original instruction
 
-    lis r4, speedModFactor@ha
-    lfs f4, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f4, g_speedModFactor@l (r4)
     fmuls f3, f3, f4
     b ItemObjKouraAo_807ad824 + 0x28
 PATCH_B_END(ItemObjKouraAo_807ad824, 0x24)
@@ -30,8 +30,8 @@ PATCH_B_END(ItemObjKouraAo_807ad824, 0x24)
 PATCH_B_START(ItemObjKouraAo_807ad824, 0x8c)
     fmuls f1, f1, f1 // Original instruction
 
-    lis r4, speedModFactor@ha
-    lfs f4, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f4, g_speedModFactor@l (r4)
     fmuls f0, f0, f4
     b ItemObjKouraAo_807ad824 + 0x90
 PATCH_B_END(ItemObjKouraAo_807ad824, 0x8c)
@@ -39,8 +39,8 @@ PATCH_B_END(ItemObjKouraAo_807ad824, 0x8c)
 PATCH_B_START(ItemObjKouraAo_807ad958, 0x24)
     lfs f1, 0x2f0 (r3) // Original instruction
 
-    lis r4, speedModFactor@ha
-    lfs f3, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f3, g_speedModFactor@l (r4)
     fmuls f2, f2, f3
     b ItemObjKouraAo_807ad958 + 0x28
 PATCH_B_END(ItemObjKouraAo_807ad958, 0x24)

--- a/payload/game/item/ItemObjKouraMidori.S
+++ b/payload/game/item/ItemObjKouraMidori.S
@@ -1,8 +1,8 @@
 #include <Common.S>
 
 PATCH_B_START(ItemObjKouraMidori_807aec64, 0x6c)
-    lis r4, speedModFactor@ha
-    lfs f2, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r4)
     fmuls f1, f1, f2
 
     bl Item_807b54f4 // Original instruction

--- a/payload/game/kart/KartMove.S
+++ b/payload/game/kart/KartMove.S
@@ -2,8 +2,8 @@
 
 PATCH_B_START(KartMove_init, 0x88)
     // Scale the initial hard speed limit
-    lis r9, speedModFactor@ha
-    lfs f2, speedModFactor@l (r9)
+    lis r9, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r9)
     fmuls f0, f0, f2
     stfs f0, 0x2c (r30) // Original instruction
     b KartMove_init + 0x8c
@@ -11,8 +11,8 @@ PATCH_B_END(KartMove_init, 0x88)
 
 PATCH_B_START(KartMove_calcAcceleration, 0x284)
     // Check that 200cc is enabled
-    lis r3, speedModIsEnabled@ha
-    lbz r3, speedModIsEnabled@l (r3)
+    lis r3, g_speedModIsEnabled@ha
+    lbz r3, g_speedModIsEnabled@l (r3)
     cmpwi r3, 0x0
     beq .Lend
 
@@ -43,56 +43,56 @@ PATCH_B_START(KartMove_calcAcceleration, 0x284)
 PATCH_B_END(KartMove_calcAcceleration, 0x284)
 
 PATCH_B_START(KartMove_setKillerStartHardSpeedLimit, 0x8)
-    lis r4, speedModFactor@ha
-    lfs f1, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f1, g_speedModFactor@l (r4)
     fmuls f0, f0, f1
     stfs f0, 0x2c (r3) // Original instruction
     blr
 PATCH_B_END(KartMove_setKillerStartHardSpeedLimit, 0x8)
 
 PATCH_B_START(KartMove_setKillerEndHardSpeedLimit, 0x8)
-    lis r4, speedModFactor@ha
-    lfs f1, speedModFactor@l (r4)
+    lis r4, g_speedModFactor@ha
+    lfs f1, g_speedModFactor@l (r4)
     fmuls f0, f0, f1
     stfs f0, 0x2c (r3) // Original instruction
     blr
 PATCH_B_END(KartMove_setKillerEndHardSpeedLimit, 0x8)
 
 PATCH_B_START(KartMove_calcSpeed, 0x210)
-    lis r3, speedModFactor@ha
-    lfs f4, speedModFactor@l (r3)
+    lis r3, g_speedModFactor@ha
+    lfs f4, g_speedModFactor@l (r3)
     fmuls f0, f0, f4
     fmuls f0, f0, f2 // Original instruction
     b KartMove_calcSpeed + 0x214
 PATCH_B_END(KartMove_calcSpeed, 0x210)
 
 PATCH_B_START(KartMove_calcSpeed, 0x3a4)
-    lis r6, speedModFactor@ha
-    lfs f2, speedModFactor@l (r6)
+    lis r6, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r6)
     fmuls f0, f0, f2
     fcmpo cr0, f0, f28 // Original instruction
     b KartMove_calcSpeed + 0x3a8
 PATCH_B_END(KartMove_calcSpeed, 0x3a4)
 
 PATCH_B_START(KartMove_calcSpeed, 0x3c8)
-    lis r6, speedModFactor@ha
-    lfs f2, speedModFactor@l (r6)
+    lis r6, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r6)
     fmuls f0, f0, f2
     fcmpo cr0, f0, f28 // Original instruction
     b KartMove_calcSpeed + 0x3cc
 PATCH_B_END(KartMove_calcSpeed, 0x3c8)
 
 PATCH_B_START(KartMove_calcCannon, 0x370)
-    lis r5, speedModReverseFactor@ha
-    lfs f7, speedModReverseFactor@l (r5)
+    lis r5, g_speedModReverseFactor@ha
+    lfs f7, g_speedModReverseFactor@l (r5)
     fmuls f0, f0, f7
     stfs f0, 0x20 (r30)
     b KartMove_calcCannon + 0x374
 PATCH_B_END(KartMove_calcCannon, 0x370)
 
 PATCH_B_START(KartMove_startKiller, 0x24)
-    lis r6, speedModFactor@ha
-    lfs f1, speedModFactor@l (r6)
+    lis r6, g_speedModFactor@ha
+    lfs f1, g_speedModFactor@l (r6)
     fmuls f0, f0, f1
     stfs f0, 0x2c (r3) // Original instruction
     b KartMove_startKiller + 0x28

--- a/payload/game/kart/KartObjectManager.cc
+++ b/payload/game/kart/KartObjectManager.cc
@@ -11,13 +11,13 @@
 
 #include <sp/settings/ClientSettings.hh>
 
-bool speedModIsEnabled;
-f32 speedModFactor;
-f32 speedModReverseFactor;
+bool g_speedModIsEnabled;
+f32 g_speedModFactor;
+f32 g_speedModReverseFactor;
 u8 s_playerDrawPriorities[12];
 
-extern f32 minDriftSpeedFactor;
-extern f32 boostAccelerations[6];
+extern f32 s_minDriftSpeedFactor;
+extern f32 s_boostAccelerations[6];
 extern f32 ai_808cb550;
 
 namespace Kart {
@@ -104,12 +104,13 @@ void KartObjectManager::CreateInstance() {
     auto *saveManager = System::SaveManager::Instance();
     auto &raceScenario = System::RaceConfig::Instance()->raceScenario();
 
-    speedModFactor = raceScenario.is200cc ? 1.5f : 1.0f;
-    speedModReverseFactor = 1.0f / speedModFactor;
+    g_speedModIsEnabled = raceScenario.is200cc;
+    g_speedModFactor = raceScenario.is200cc ? 1.5f : 1.0f;
+    g_speedModReverseFactor = 1.0f / g_speedModFactor;
 
-    minDriftSpeedFactor = 0.55f / speedModFactor;
-    boostAccelerations[0] = 3.0f * speedModFactor;
-    ai_808cb550 = 70.0f * speedModFactor;
+    s_minDriftSpeedFactor = 0.55f / g_speedModFactor;
+    s_boostAccelerations[0] = 3.0f * g_speedModFactor;
+    ai_808cb550 = 70.0f * g_speedModFactor;
 
     auto value = saveManager->getSetting<SP::ClientSettings::Setting::VanillaMode>();
     bool isVanilla = value == SP::ClientSettings::VanillaMode::Enable;

--- a/payload/game/kart/KartObjectManager.hh
+++ b/payload/game/kart/KartObjectManager.hh
@@ -2,10 +2,6 @@
 
 #include "game/kart/KartObject.hh"
 
-extern bool speedModIsEnabled;
-extern f32 speedModFactor;
-extern f32 speedModReverseFactor;
-
 namespace Kart {
 
 class KartObjectManager {

--- a/payload/game/kart/KartParam.S
+++ b/payload/game/kart/KartParam.S
@@ -1,8 +1,8 @@
 #include <Common.S>
 
 PATCH_B_START(KartParam_compute, 0x1f0)
-    lis r5, speedModFactor@ha
-    lfs f2, speedModFactor@l (r5)
+    lis r5, g_speedModFactor@ha
+    lfs f2, g_speedModFactor@l (r5)
 
     lfs f3, 0xc (r3)
     fmuls f3, f3, f2

--- a/payload/game/kart/KartSub.S
+++ b/payload/game/kart/KartSub.S
@@ -10,8 +10,8 @@ PATCH_BL_START(KartSub_calcPass0, 0x310)
     stfs f0, 0x148 (r4) // Original instruction
 
     // Check that 200cc is enabled
-    lis r5, speedModIsEnabled@ha
-    lbz r5, speedModIsEnabled@l (r5)
+    lis r5, g_speedModIsEnabled@ha
+    lbz r5, g_speedModIsEnabled@l (r5)
     cmpwi r5, 0x0
     beqlr
 
@@ -61,8 +61,8 @@ PATCH_BL_START(KartSub_calcPass1, 0x694)
     mr r3, r28 // Original instruction
 
     // Check that 200cc is enabled
-    lis r4, speedModIsEnabled@ha
-    lbz r4, speedModIsEnabled@l (r4)
+    lis r4, g_speedModIsEnabled@ha
+    lbz r4, g_speedModIsEnabled@l (r4)
     cmpwi r4, 0x0
     beqlr
 

--- a/payload/game/sound/Snd.S
+++ b/payload/game/sound/Snd.S
@@ -4,8 +4,8 @@ PATCH_BL_START(Snd_806fafb4, 0x44)
     extrwi r27, r0, 1, 29 // Original instruction
 
     // Check that 200cc is enabled
-    lis r5, speedModIsEnabled@ha
-    lbz r5, speedModIsEnabled@l (r5)
+    lis r5, g_speedModIsEnabled@ha
+    lbz r5, g_speedModIsEnabled@l (r5)
     cmpwi r5, 0x0
     beqlr
 

--- a/payload/game/system/InputManager.S
+++ b/payload/game/system/InputManager.S
@@ -4,8 +4,8 @@ PATCH_BL_START(WiiPad_processClassic, 0x1e8)
     ori r6, r6, 0x1 // Original instruction
 
     // Check that 200cc is enabled
-    lis r8, speedModIsEnabled@ha
-    lbz r8, speedModIsEnabled@l (r8)
+    lis r8, g_speedModIsEnabled@ha
+    lbz r8, g_speedModIsEnabled@l (r8)
     cmpwi r8, 0x0
     beqlr
 
@@ -23,8 +23,8 @@ PATCH_BL_START(GcPad_process, 0xec)
     ori r8, r8, 0x1 // Original instruction
 
     // Check that 200cc is enabled
-    lis r4, speedModIsEnabled@ha
-    lbz r4, speedModIsEnabled@l (r4)
+    lis r4, g_speedModIsEnabled@ha
+    lbz r4, g_speedModIsEnabled@l (r4)
     cmpwi r4, 0x0
     beqlr
 

--- a/payload/game/ui/AwardPage.cc
+++ b/payload/game/ui/AwardPage.cc
@@ -1,6 +1,5 @@
 #include "AwardPage.hh"
 
-#include "game/kart/KartObjectManager.hh" // speedModIsEnabled
 #include "game/system/RaceConfig.hh"
 #include "game/ui/SectionManager.hh"
 
@@ -77,7 +76,7 @@ void AwardPage::initType() {
         case System::RaceConfig::EngineClass::CC150:
             if (awardsScenario.mirror) {
                 cupInfo.messageIds[0] = 1420;
-            } else if (speedModIsEnabled) {
+            } else if (awardsScenario.is200cc) {
                 cupInfo.messageIds[0] = 10072;
             } else {
                 cupInfo.messageIds[0] = 1419;

--- a/payload/game/ui/page/DemoPage.cc
+++ b/payload/game/ui/page/DemoPage.cc
@@ -1,6 +1,5 @@
 #include "DemoPage.hh"
 
-#include "game/kart/KartObjectManager.hh"
 #include "game/system/RaceConfig.hh"
 #include "game/ui/SectionManager.hh"
 
@@ -37,7 +36,7 @@ void DemoPage::onInit() {
     if (currentSectionId == SectionId::GPDemo || currentSectionId == SectionId::VSDemo) {
         if (raceScenario.mirror) {
             cupInfo.messageIds[0] = 1420;
-        } else if (speedModIsEnabled) {
+        } else if (raceScenario.is200cc) {
             cupInfo.messageIds[0] = 10072;
         } else {
             cupInfo.messageIds[0] = 1417 + static_cast<u32>(raceScenario.engineClass);

--- a/payload/game/util/Input.S
+++ b/payload/game/util/Input.S
@@ -4,8 +4,8 @@ PATCH_BL_START(Input_80745be4, 0xd0)
     ori r31, r31, 0x1 // Original instruction
 
     // Check that 200cc is enabled
-    lis r6, speedModIsEnabled@ha
-    lbz r6, speedModIsEnabled@l (r6)
+    lis r6, g_speedModIsEnabled@ha
+    lbz r6, g_speedModIsEnabled@l (r6)
     cmpwi r6, 0x0
     beqlr
 
@@ -23,8 +23,8 @@ PATCH_BL_START(Input_80745de4, 0x18c)
     ori r0, r0, 0x1 // Original instruction
 
     // Check that 200cc is enabled
-    lis r3, speedModIsEnabled@ha
-    lbz r3, speedModIsEnabled@l (r3)
+    lis r3, g_speedModIsEnabled@ha
+    lbz r3, g_speedModIsEnabled@l (r3)
     cmpwi r3, 0x0
     beqlr
 

--- a/payload/sp/SaveStateManager.cc
+++ b/payload/sp/SaveStateManager.cc
@@ -1,7 +1,5 @@
 #include "SaveStateManager.hh"
 
-#include "game/kart/KartObjectManager.hh"
-
 extern "C" {
 #include "revolution.h"
 }

--- a/symbols.txt
+++ b/symbols.txt
@@ -1472,8 +1472,8 @@
 0x808ad3c4 RaceCupSelectPage_zero
 
 0x808b3984 _ZN8Registry15courseFilenamesE
-0x808b5b1c minDriftSpeedFactor
-0x808b5c78 boostAccelerations
+0x808b5b1c s_minDriftSpeedFactor
+0x808b5c78 s_boostAccelerations
 0x808cb550 ai_808cb550
 0x808D3E14 playerTagRenderDistance
 0x808da070 _ZN2UI11TopMenuPage13s_buttonNamesE


### PR DESCRIPTION
Closes #747.

I accidentally removed the speedModIsEnabled setting in #675, this PR fixes that and uses the Scenario is200cc flag over the global wherever possible.