### PR TITLE
Fix legacy `PATCH_BL` for C++

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -191,8 +191,8 @@ typedef struct {
             .type = PATCH_TYPE_BRANCH, \
             .branch = \
                     { \
-                            &from, \
-                            &to, \
+                            (char *)(void *)(&from), \
+                            (char *)(void *)(&to), \
                             link, \
                             thunk, \
                     }, \


### PR DESCRIPTION
If we want to keep it, this could allow us to delete a bunch of .C files and move them into their corresponding C++ source file.