### PR TITLE
Add assertion to GroupContainer_FindGroupByName

### DIFF
--- a/payload/nw4r/lyt/lyt_GroupContainer.cc
+++ b/payload/nw4r/lyt/lyt_GroupContainer.cc
@@ -1,0 +1,10 @@
+#include "Common.hh"
+
+extern "C" void *REPLACED(GroupContainer_FindGroupByName)(void *a, const char *b);
+extern "C" REPLACE void *GroupContainer_FindGroupByName(void *a, const char *b) {
+    void *r = REPLACED(GroupContainer_FindGroupByName)(a, b);
+    if (r == nullptr) {
+        panic("Failed to find group %s", b);
+    }
+    return r;
+}


### PR DESCRIPTION
This was useful in discovering a mislabled `pane` field is actually a GroupContainer name and should help make the UI system more friendly to work with.